### PR TITLE
Limit logging to API booking identifiers

### DIFF
--- a/includes/bokun-bookings-manager.php
+++ b/includes/bokun-bookings-manager.php
@@ -103,7 +103,6 @@ function bokun_fetch_bookings($upgrade = '') {
         $response = wp_remote_post($url, $args);
 
         if (is_wp_error($response)) {
-            error_log('Error fetching bookings on page ' . $page . ': ' . $response->get_error_message());
             return $page === 1 ? 'Error: ' . $response->get_error_message() : $all_bookings;
         }
 
@@ -111,13 +110,17 @@ function bokun_fetch_bookings($upgrade = '') {
         $body = wp_remote_retrieve_body($response);
 
         if ($response_code !== 200) {
-            error_log('Unexpected response code on page ' . $page . ': ' . $response_code . ' with body: ' . $body);
             return $page === 1 ? 'Error: Received unexpected response code ' . $response_code . '. Response: ' . $body : $all_bookings;
         }
 
         $data = json_decode($body, true);
 
         if (isset($data['items']) && is_array($data['items'])) {
+            foreach ($data['items'] as $item) {
+                if (!empty($item['confirmationCode'])) {
+                    error_log('Found booking ' . $item['confirmationCode']);
+                }
+            }
             $all_bookings = array_merge($all_bookings, $data['items']);
         }
 
@@ -271,7 +274,6 @@ function bokun_save_bookings_as_posts($bookings) {
         } else {
             $post_id = wp_insert_post($post_data);
             if (is_wp_error($post_id)) {
-                error_log('Error inserting post for confirmationCode: ' . $confirmationCode . '. Error: ' . $post_id->get_error_message());
                 continue;
             }
         }
@@ -291,9 +293,6 @@ $inclusions_clean = bokun_get_inclusions_clean($inclusions_text);
 
 if (!empty($inclusions_clean)) {
     update_post_meta($post_id, 'inclusions_clean', $inclusions_clean);
-    error_log('Processed Inclusions Clean: ' . $inclusions_clean);
-} else {
-    error_log('Inclusions Clean is empty.');
 }
 
     }
@@ -427,7 +426,6 @@ function bokun_assign_tag_to_post($post_id, $term_name, $taxonomy) {
         // If not, create it
         $term = wp_insert_term($term_name, $taxonomy);
         if (is_wp_error($term)) {
-            error_log("Error inserting term '$term_name' into taxonomy '$taxonomy': " . $term->get_error_message());
             return;
         }
         $term_id = $term['term_id'];
@@ -475,7 +473,6 @@ function bokun_calculate_booking_status($post_id, $product_title, $startDateTime
         $timezone = new DateTimeZone($timezone_string);
         $current_date = new DateTime('now', $timezone);
     } catch (Exception $e) {
-        error_log('Invalid timezone: ' . $timezone_string . ' - Falling back to UTC.');
         $timezone = new DateTimeZone('UTC');
         $current_date = new DateTime('now', $timezone);
     }
@@ -535,7 +532,6 @@ function bokun_assign_alarm_status_taxonomy($post_id, $alarm_status) {
     if (!$term) {
         $term = wp_insert_term($alarm_status, $taxonomy);
         if (is_wp_error($term)) {
-            error_log("Error inserting term '$alarm_status' into taxonomy '$taxonomy': " . $term->get_error_message());
             return;
         }
         // Extract the term name (in case wp_insert_term returns a term array)
@@ -563,9 +559,7 @@ function bokun_save_all_fields_as_meta($post_id, $data, $prefix = '') {
             // If the value is a JSON string, decode it
             if (is_string($value) && is_json($value)) {
                 $decoded_value = json_decode($value, true);
-                if (json_last_error() !== JSON_ERROR_NONE) {
-                    error_log("JSON decode error on $meta_key: " . json_last_error_msg());
-                } else {
+                if (json_last_error() === JSON_ERROR_NONE) {
                     $value = $decoded_value;
                 }
             }
@@ -917,10 +911,8 @@ function bokun_import_bookings() {
     $bookings = bokun_fetch_bookings();    
     if (is_array($bookings)) {
         bokun_save_bookings_as_posts($bookings);
-        error_log('Bookings imported successfully.');
         return new WP_REST_Response('Bookings imported successfully.', 200);
     } else {
-        error_log('Error fetching bookings: ' . $bookings);
         return new WP_REST_Response('Error fetching bookings: ' . $bookings, 500);
     }
 }
@@ -993,7 +985,6 @@ function bokun_get_inclusions_clean($text) {
     
     // Split the text by '---'
     $parts = explode('---', $text);
-    error_log('Inclusions Parts: ' . print_r($parts, true)); // Log parts for debugging
     
     // Ensure we have at least 4 parts (3 separators before inclusions)
     if (count($parts) >= 4) {


### PR DESCRIPTION
## Summary
- remove existing debug logging statements that were populating wp-content/debug.log
- add logging during API fetches to note each booking found by confirmation code

## Testing
- php -l includes/bokun-bookings-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68d57aa0298083209635b57d2ed7012b