### PR TITLE
Add frontend dashboard shortcode for upcoming bookings

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -118,3 +118,219 @@
   border-left-color: #d63638;
 }
 
+.bokun-booking-dashboard {
+  --bokun-booking-dashboard-columns: 3;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin: 2rem 0;
+}
+
+@media (min-width: 1024px) {
+  .bokun-booking-dashboard {
+    grid-template-columns: repeat(var(--bokun-booking-dashboard-columns), minmax(0, 1fr));
+  }
+}
+
+.bokun-booking-dashboard__empty {
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: #1e293b;
+}
+
+.bokun-booking-dashboard__card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.04);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.bokun-booking-dashboard__card:hover,
+.bokun-booking-dashboard__card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+}
+
+.bokun-booking-dashboard__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.bokun-booking-dashboard__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.bokun-booking-dashboard__title a:hover,
+.bokun-booking-dashboard__title a:focus {
+  color: #2563eb;
+}
+
+.bokun-booking-dashboard__code {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #475569;
+  white-space: nowrap;
+}
+
+.bokun-booking-dashboard__status-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bokun-booking-dashboard__status-item {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.bokun-booking-dashboard__details {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.bokun-booking-dashboard__detail {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  color: #334155;
+}
+
+.bokun-booking-dashboard__detail dt {
+  flex: 0 0 auto;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.bokun-booking-dashboard__detail dd {
+  margin: 0;
+}
+
+.bokun-booking-dashboard__time {
+  display: inline-block;
+  margin-left: 0.5rem;
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.bokun-booking-dashboard__participants {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bokun-booking-dashboard__participants li {
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.75rem;
+  background: #f1f5f9;
+  color: #1e293b;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.bokun-booking-dashboard__inclusions {
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.75rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.bokun-booking-dashboard__section-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__inclusions p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.bokun-booking-dashboard__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.bokun-booking-dashboard__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #1f2937;
+  cursor: pointer;
+}
+
+.bokun-booking-dashboard__toggle input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+}
+
+.bokun-booking-dashboard__footer {
+  margin-top: auto;
+  padding-top: 0.75rem;
+}
+
+.bokun-booking-dashboard__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.bokun-booking-dashboard__link:hover,
+.bokun-booking-dashboard__link:focus {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+.bokun-booking-dashboard__card.alarm_status-alarm {
+  border-color: #f97316;
+}
+
+.bokun-booking-dashboard__card.alarm_status-attention {
+  border-color: #facc15;
+}
+
+.bokun-booking-dashboard__card.alarm_status-ok {
+  border-color: #22c55e;
+}
+

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -7,6 +7,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
 
             add_shortcode('bokun_fetch_button', array($this, "function_bokun_fetch_button" ) );
             add_shortcode('bokun_booking_history', array($this, 'render_booking_history_table'));
+            add_shortcode('bokun_booking_dashboard', array($this, 'render_booking_dashboard'));
 
         }
 
@@ -469,6 +470,292 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 </table>
             </div>
             <?php
+            return ob_get_clean();
+        }
+
+
+        public function render_booking_dashboard($atts = []) {
+            if (!post_type_exists('bokun_booking')) {
+                return '';
+            }
+
+            $atts = shortcode_atts(
+                [
+                    'days'    => 30,
+                    'columns' => 3,
+                ],
+                $atts,
+                'bokun_booking_dashboard'
+            );
+
+            $days = max(1, absint($atts['days']));
+            $columns = max(1, min(6, absint($atts['columns'])));
+
+            $now_timestamp = current_time('timestamp');
+            $range_end     = strtotime('+' . $days . ' days', $now_timestamp);
+
+            if (false === $range_end) {
+                $range_end = $now_timestamp;
+            }
+
+            $query = new WP_Query(
+                [
+                    'post_type'           => 'bokun_booking',
+                    'post_status'         => 'publish',
+                    'posts_per_page'      => -1,
+                    'ignore_sticky_posts' => true,
+                    'no_found_rows'       => true,
+                    'meta_key'            => '_original_start_date',
+                    'meta_type'           => 'DATETIME',
+                    'orderby'             => [
+                        'meta_value' => 'ASC',
+                        'date'       => 'ASC',
+                    ],
+                    'date_query'          => [
+                        [
+                            'column'    => 'post_date_gmt',
+                            'after'     => current_time('mysql', true),
+                            'before'    => gmdate('Y-m-d H:i:s', $range_end),
+                            'inclusive' => true,
+                        ],
+                    ],
+                ]
+            );
+
+            if (!$query->have_posts()) {
+                return sprintf(
+                    '<div class="bokun-booking-dashboard__empty">%s</div>',
+                    esc_html(
+                        sprintf(
+                            /* translators: %d: number of days in the dashboard range. */
+                            __('No upcoming bookings were found for the next %d days.', 'BOKUN_txt_domain'),
+                            $days
+                        )
+                    )
+                );
+            }
+
+            ob_start();
+
+            $columns_style = sprintf('style="--bokun-booking-dashboard-columns: %d"', $columns);
+
+            echo '<div class="bokun-booking-dashboard" ' . $columns_style . '>';
+
+            while ($query->have_posts()) {
+                $query->the_post();
+
+                $post_id           = get_the_ID();
+                $permalink         = get_permalink($post_id);
+                $post_classes      = get_post_class('bokun-booking-dashboard__card', $post_id);
+                $booking_code      = get_post_meta($post_id, '_confirmation_code', true);
+                $product_title     = get_post_meta($post_id, '_product_title', true);
+                $meeting_point     = get_post_meta($post_id, 'bk_meetingpointtitle', true);
+                $external_ref      = get_post_meta($post_id, '_external_booking_reference', true);
+                $customer_first    = get_post_meta($post_id, '_first_name', true);
+                $customer_last     = get_post_meta($post_id, '_last_name', true);
+                $phone_prefix      = get_post_meta($post_id, '_phone_prefix', true);
+                $phone_number      = get_post_meta($post_id, '_phone_number', true);
+                $created_at        = get_post_meta($post_id, 'bookingcreationdate', true);
+                $inclusions        = get_post_meta($post_id, 'inclusions_clean', true);
+                $start_raw         = get_post_meta($post_id, '_original_start_date', true);
+                $participants      = [];
+
+                foreach (range(1, 5) as $index) {
+                    $value = get_post_meta($post_id, 'pricecategory' . $index, true);
+
+                    if (!empty($value)) {
+                        $participants[] = $value;
+                    }
+                }
+
+                $customer_name = trim(sprintf('%s %s', $customer_first, $customer_last));
+                if ('' === $customer_name) {
+                    $customer_name = $customer_first ?: $customer_last;
+                }
+
+                $phone_display = trim(sprintf('%s %s', $phone_prefix, $phone_number));
+
+                $start_timestamp = $start_raw ? strtotime((string) $start_raw) : false;
+
+                if (false === $start_timestamp) {
+                    $formatted_start = bokun_format_booking_datetime($start_raw);
+                    if ('' !== $formatted_start) {
+                        $start_timestamp = strtotime($formatted_start);
+                    }
+                }
+
+                if (false === $start_timestamp) {
+                    $start_timestamp = get_post_time('U', true, $post_id);
+                }
+
+                $start_date_display = $start_timestamp ? wp_date(get_option('date_format'), $start_timestamp) : '';
+                $start_time_display = $start_timestamp ? wp_date(get_option('time_format'), $start_timestamp) : '';
+
+                $status_terms = get_the_terms($post_id, 'booking_status');
+                $status_labels = [];
+
+                if ($status_terms && !is_wp_error($status_terms)) {
+                    foreach ($status_terms as $term) {
+                        $status_labels[] = $term->name;
+                    }
+                }
+
+                $team_terms = get_the_terms($post_id, 'team_member');
+                $team_labels = [];
+
+                if ($team_terms && !is_wp_error($team_terms)) {
+                    foreach ($team_terms as $term) {
+                        $team_labels[] = $term->name;
+                    }
+                }
+
+                $checkbox_states = [
+                    'full'           => has_term('full', 'booking_status', $post_id),
+                    'partial'        => has_term('partial', 'booking_status', $post_id),
+                    'not-available'  => has_term('not-available', 'booking_status', $post_id),
+                    'refund-partner' => has_term('refund-requested-from-partner', 'booking_status', $post_id),
+                ];
+
+                $card_class_attribute = esc_attr(implode(' ', $post_classes));
+                ?>
+                <article class="<?php echo $card_class_attribute; ?>" data-booking-id="<?php echo esc_attr($booking_code); ?>">
+                    <header class="bokun-booking-dashboard__header">
+                        <h3 class="bokun-booking-dashboard__title">
+                            <?php if (!empty($permalink)) : ?>
+                                <a href="<?php echo esc_url($permalink); ?>">
+                                    <?php echo esc_html(get_the_title($post_id)); ?>
+                                </a>
+                            <?php else : ?>
+                                <?php echo esc_html(get_the_title($post_id)); ?>
+                            <?php endif; ?>
+                        </h3>
+                        <?php if (!empty($booking_code)) : ?>
+                            <span class="bokun-booking-dashboard__code"><?php echo esc_html($booking_code); ?></span>
+                        <?php endif; ?>
+                    </header>
+
+                    <?php if (!empty($status_labels)) : ?>
+                        <ul class="bokun-booking-dashboard__status-list">
+                            <?php foreach ($status_labels as $status_label) : ?>
+                                <li class="bokun-booking-dashboard__status-item"><?php echo esc_html($status_label); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+
+                    <dl class="bokun-booking-dashboard__details">
+                        <?php if (!empty($product_title)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Product', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html($product_title); ?></dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($start_date_display) || !empty($start_time_display)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Start', 'BOKUN_txt_domain'); ?></dt>
+                                <dd>
+                                    <?php if (!empty($start_date_display)) : ?>
+                                        <time datetime="<?php echo esc_attr(wp_date('c', $start_timestamp)); ?>"><?php echo esc_html($start_date_display); ?></time>
+                                    <?php endif; ?>
+                                    <?php if (!empty($start_time_display)) : ?>
+                                        <span class="bokun-booking-dashboard__time"><?php echo esc_html($start_time_display); ?></span>
+                                    <?php endif; ?>
+                                </dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($meeting_point)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Meeting point', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html($meeting_point); ?></dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($customer_name)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Lead traveller', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html($customer_name); ?></dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($phone_display)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Phone', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html($phone_display); ?></dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($external_ref)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Reference', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html($external_ref); ?></dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($created_at)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Created', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html($created_at); ?></dd>
+                            </div>
+                        <?php endif; ?>
+
+                        <?php if (!empty($team_labels)) : ?>
+                            <div class="bokun-booking-dashboard__detail">
+                                <dt><?php esc_html_e('Team members', 'BOKUN_txt_domain'); ?></dt>
+                                <dd><?php echo esc_html(implode(', ', $team_labels)); ?></dd>
+                            </div>
+                        <?php endif; ?>
+                    </dl>
+
+                    <?php if (!empty($participants)) : ?>
+                        <ul class="bokun-booking-dashboard__participants">
+                            <?php foreach ($participants as $participant) : ?>
+                                <li><?php echo esc_html($participant); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+
+                    <?php if (!empty($inclusions)) : ?>
+                        <div class="bokun-booking-dashboard__inclusions">
+                            <h4 class="bokun-booking-dashboard__section-title"><?php esc_html_e('Inclusions & notes', 'BOKUN_txt_domain'); ?></h4>
+                            <p><?php echo wp_kses_post(nl2br(esc_html($inclusions))); ?></p>
+                        </div>
+                    <?php endif; ?>
+
+                    <div class="bokun-booking-dashboard__toggles" role="group" aria-label="<?php esc_attr_e('Booking status toggles', 'BOKUN_txt_domain'); ?>">
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="full" <?php echo checked($checkbox_states['full'], true, false); ?> />
+                            <span><?php esc_html_e('Full', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="partial" <?php echo checked($checkbox_states['partial'], true, false); ?> />
+                            <span><?php esc_html_e('Partial', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="not-available" <?php echo checked($checkbox_states['not-available'], true, false); ?> />
+                            <span><?php esc_html_e('Not available', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="refund-partner" <?php echo checked($checkbox_states['refund-partner'], true, false); ?> />
+                            <span><?php esc_html_e('Refund requested', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                    </div>
+
+                    <?php if (!empty($permalink)) : ?>
+                        <div class="bokun-booking-dashboard__footer">
+                            <a class="bokun-booking-dashboard__link" href="<?php echo esc_url($permalink); ?>">
+                                <?php esc_html_e('Open booking', 'BOKUN_txt_domain'); ?>
+                            </a>
+                        </div>
+                    <?php endif; ?>
+                </article>
+                <?php
+            }
+
+            echo '</div>';
+
+            wp_reset_postdata();
+
             return ob_get_clean();
         }
 


### PR DESCRIPTION
## Summary
- add a [bokun_booking_dashboard] shortcode that renders a grid of published bookings within the next 30 days including key metadata and status toggles
- add responsive dashboard styles to the front-end stylesheet to support the new layout

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_6906b098f3288320b05d85708ba63a3a