### PR TITLE
Add global search and filters to booking dashboard

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -126,6 +126,82 @@
   margin: 2rem 0;
 }
 
+.bokun-booking-dashboard__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.bokun-booking-dashboard__search {
+  flex: 1 1 240px;
+  min-width: 220px;
+}
+
+.bokun-booking-dashboard__search label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+  color: #1e293b;
+}
+
+.bokun-booking-dashboard__search-input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5e1;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bokun-booking-dashboard__search-input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  outline: none;
+}
+
+.bokun-booking-dashboard__filter {
+  border: 1px solid #dbeafe;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem 1rem;
+  background: #f8fafc;
+  min-width: 220px;
+  flex: 1 1 220px;
+}
+
+.bokun-booking-dashboard__filter legend {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 0.5rem;
+}
+
+.bokun-booking-dashboard__filter-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.bokun-booking-dashboard__filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__filter-option input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.25rem;
+  border: 1px solid #cbd5e1;
+}
+
+.bokun-booking-dashboard__empty--filtered[hidden] {
+  display: none;
+}
+
 .bokun-booking-dashboard__tabs {
   display: inline-flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add a dashboard-level search bar and checkbox filters for statuses and team members
- annotate booking cards with searchable metadata and update tab counts/empty messages via JavaScript
- style the new controls to match the existing dashboard presentation

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_6906bb72eae08320a50dc91ae8dd5707