### PR TITLE
Add dashboard page selection and update booking links

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -472,6 +472,7 @@
 .bokun-booking-dashboard__reserve-link:hover,
 .bokun-booking-dashboard__reserve-link:focus {
   background: #1d4ed8;
+  color: #ffffff;
   transform: translateY(-1px);
   outline: none;
 }

--- a/assets/js/bokun_admin_js.js
+++ b/assets/js/bokun_admin_js.js
@@ -225,15 +225,15 @@ jQuery(document).ready(function ($) {
 		});
 	});
 	
-	jQuery(document).on('click', '.bokun_api_auth_save_upgrade', function () {
-		var form = jQuery('#bokun_api_auth_form_upgrade')[0];
-		var formData = new FormData(form);
-		formData.append('action', 'bokun_save_api_auth_upgrade');
-		formData.append('security', bokun_api_auth_vars.nonce);
+        jQuery(document).on('click', '.bokun_api_auth_save_upgrade', function () {
+                var form = jQuery('#bokun_api_auth_form_upgrade')[0];
+                var formData = new FormData(form);
+                formData.append('action', 'bokun_save_api_auth_upgrade');
+                formData.append('security', bokun_api_auth_vars.nonce);
 
-		jQuery.ajax({
-			type: 'POST',
-			url: ajaxurl,
+                jQuery.ajax({
+                        type: 'POST',
+                        url: ajaxurl,
 			data: formData,
 			processData: false,
 			contentType: false,
@@ -254,9 +254,61 @@ jQuery(document).ready(function ($) {
 			error: function (xhr, status, error) {
 				console.error('Error:', error);
 				alert('An error occurred. Please try again.');
-			}
-		});
-	});
+                        }
+                });
+        });
+
+        jQuery(document).on('click', '.bokun_dashboard_settings_save', function () {
+                var form = jQuery('#bokun_dashboard_settings_form')[0];
+
+                if (!form) {
+                        return;
+                }
+
+                var ajaxUrl = (typeof ajaxurl !== 'undefined' && ajaxurl) ? ajaxurl : (bokun_api_auth_vars && bokun_api_auth_vars.ajax_url ? bokun_api_auth_vars.ajax_url : '');
+
+                if (!ajaxUrl) {
+                        return;
+                }
+
+                var formData = new FormData(form);
+                formData.append('action', 'bokun_save_dashboard_settings');
+                formData.append('security', bokun_api_auth_vars.nonce);
+
+                jQuery.ajax({
+                        type: 'POST',
+                        url: ajaxUrl,
+                        data: formData,
+                        processData: false,
+                        contentType: false,
+                        dataType: 'json',
+                        success: function (res) {
+                                jQuery('.msg_dashboard_success, .msg_dashboard_error').hide();
+
+                                if (res && res.success) {
+                                        var message = res.data && res.data.msg ? decodeHTMLEntities(res.data.msg) : '';
+                                        jQuery('.msg_dashboard_success p').html('<strong>Success:</strong> ' + message);
+                                        jQuery('.msg_dashboard_success').show();
+                                } else {
+                                        var errorMessage = res && res.data && res.data.msg ? decodeHTMLEntities(res.data.msg) : 'An unexpected error occurred.';
+                                        jQuery('.msg_dashboard_error p').html('<strong>Error:</strong> ' + errorMessage);
+                                        jQuery('.msg_dashboard_error').show();
+                                }
+                        },
+                        error: function (xhr, status, error) {
+                                jQuery('.msg_dashboard_success').hide();
+                                var message = 'An error occurred. Please try again.';
+
+                                if (xhr && xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.msg) {
+                                        message = decodeHTMLEntities(xhr.responseJSON.data.msg);
+                                }
+
+                                jQuery('.msg_dashboard_error p').html('<strong>Error:</strong> ' + message);
+                                jQuery('.msg_dashboard_error').show();
+                                console.error('Error:', error);
+                        }
+                });
+        });
 
         jQuery(document).on('click', '.bokun_fetch_booking_data', function (e) {
                 e.preventDefault();

--- a/bokun-bookings-management.php
+++ b/bokun-bookings-management.php
@@ -83,8 +83,9 @@ class BokunBookingManagement {
         
         add_action('init', array( $this,'bokun_register_booking_status_taxonomy'));
         add_action('init', array( $this,'bokun_register_team_member_taxonomy'));
-        
-	}
+        add_filter('the_content', array( $this, 'bokun_maybe_append_dashboard_to_page' ));
+
+        }
     
 
     // Register custom taxonomy for Booking Status    
@@ -134,6 +135,35 @@ class BokunBookingManagement {
                 'show_in_rest' => true,
             ]
         );
+    }
+
+
+    function bokun_maybe_append_dashboard_to_page($content) {
+        if (is_admin()) {
+            return $content;
+        }
+
+        if (!is_singular('page') || !in_the_loop() || !is_main_query()) {
+            return $content;
+        }
+
+        $dashboard_page_id = absint(get_option('bokun_dashboard_page_id', 0));
+
+        if ($dashboard_page_id <= 0 || get_the_ID() !== $dashboard_page_id) {
+            return $content;
+        }
+
+        if (has_shortcode($content, 'bokun_booking_dashboard')) {
+            return $content;
+        }
+
+        $dashboard_content = do_shortcode('[bokun_booking_dashboard]');
+
+        if (empty($dashboard_content)) {
+            return $content;
+        }
+
+        return $content . $dashboard_content;
     }
     
 

--- a/includes/bokun_settings.view.php
+++ b/includes/bokun_settings.view.php
@@ -3,10 +3,22 @@ $api_key = get_option('bokun_api_key', '');
 $secret_key = get_option('bokun_secret_key', '');
 $api_key_upgrade = get_option('bokun_api_key_upgrade', '');
 $secret_key_upgrade = get_option('bokun_secret_key_upgrade', '');
+$dashboard_page_id = (int) get_option('bokun_dashboard_page_id', 0);
+$dashboard_page_dropdown = wp_dropdown_pages(
+    array(
+        'name'              => 'dashboard_page_id',
+        'id'                => 'bokun_dashboard_page_select',
+        'class'             => 'widefat',
+        'selected'          => $dashboard_page_id,
+        'show_option_none'  => __('— Select a page —', 'BOKUN_txt_domain'),
+        'option_none_value' => '0',
+        'echo'              => false,
+    )
+);
 ?>
 <div id="booking">
     <div class="container-fluid">
-        
+
         <div class="row">
             
             <div class="col-4 text-center ">
@@ -111,6 +123,39 @@ $secret_key_upgrade = get_option('bokun_secret_key_upgrade', '');
                 </div>
             </div>
 
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <h2><?php esc_html_e('Booking dashboard display', 'BOKUN_txt_domain'); ?></h2>
+                    <p>
+                        <?php esc_html_e('Use the [bokun_booking_dashboard] shortcode or choose a page below to automatically display the dashboard.', 'BOKUN_txt_domain'); ?>
+                    </p>
+                    <div class="notice notice-info is-dismissible msg_dashboard_success" style="display:none;">
+                        <p>
+                            <strong><?php esc_html_e('Success:', 'BOKUN_txt_domain'); ?></strong>
+                        </p>
+                    </div>
+                    <div class="notice notice-error is-dismissible msg_dashboard_error" style="display:none;">
+                        <p>
+                            <strong><?php esc_html_e('Error:', 'BOKUN_txt_domain'); ?></strong>
+                        </p>
+                    </div>
+                    <form method="post" action="javascript:;" id="bokun_dashboard_settings_form" name="bokun_dashboard_settings_form" enctype='multipart/form-data'>
+                        <div class="bokun_cmrc-table">
+                            <div class="bokun_settings-fb-config">
+                                <label for="bokun_dashboard_page_select"><?php esc_html_e('Dashboard page', 'BOKUN_txt_domain'); ?>:</label>
+                                <?php echo $dashboard_page_dropdown; ?>
+                                <p class="description">
+                                    <?php esc_html_e('Select a page to automatically append the booking dashboard content. Leave blank to manage placement with the shortcode.', 'BOKUN_txt_domain'); ?>
+                                </p>
+                                <input type="submit" name="submit" class="button button-primary bokun_dashboard_settings_save" value="<?php esc_attr_e('Save dashboard settings', 'BOKUN_txt_domain'); ?>">
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -614,7 +614,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 $viator_url = '';
                 if ($external_ref !== '') {
                     $viator_url = sprintf(
-                        'https://supplier.viator.com/messaging/conversation/booking/%s/',
+                        'https://supplier.viator.com/messaging/conversation/booking/%s',
                         rawurlencode($external_ref)
                     );
                 }
@@ -622,7 +622,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 $bokun_url = '';
                 if ($parent_booking_id !== '') {
                     $bokun_url = sprintf(
-                        'https://florenceadventuressrl.bokun.io/sales/%s/',
+                        'https://florenceadventuressrl.bokun.io/sales/%s',
                         rawurlencode($parent_booking_id)
                     );
                 }
@@ -765,7 +765,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 $partner_page_url = '';
                 if (!empty($partner_page_id)) {
                     $partner_page_url = sprintf(
-                        'https://extranet.ciaoflorence.it/en/tourDetails/%s/',
+                        'https://extranet.ciaoflorence.it/en/tourDetails/%s',
                         rawurlencode($partner_page_id)
                     );
                 }


### PR DESCRIPTION
## Summary
- allow the booking dashboard to be assigned to a specific page from the plugin settings while keeping shortcode usage available
- append the dashboard content automatically on the selected page and add the supporting AJAX handler and admin UI
- remove trailing slashes from external dashboard links and keep the reserve button text readable on hover

## Testing
- php -l bokun-bookings-management.php
- php -l includes/bokun_settings.class.php
- php -l includes/bokun_settings.view.php
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_6907ff9df02c83208558a32bda33f02c