### PR TITLE
Adjust booking history page layout

### DIFF
--- a/includes/bokun_booking_history.view.php
+++ b/includes/bokun_booking_history.view.php
@@ -122,7 +122,24 @@ if (!empty($logs)) {
     }
 }
 ?>
-<div class="wrap">
+<div class="wrap bokun-history-wrap">
+    <style>
+        .bokun-history-wrap {
+            margin: 0;
+            max-width: none;
+            width: 100%;
+            padding-left: 16px;
+            padding-right: 16px;
+            box-sizing: border-box;
+        }
+
+        @media (min-width: 782px) {
+            .bokun-history-wrap {
+                padding-left: 24px;
+                padding-right: 24px;
+            }
+        }
+    </style>
     <h1><?php esc_html_e('Booking History', 'BOKUN_txt_domain'); ?></h1>
 
     <?php if (!$table_exists) : ?>


### PR DESCRIPTION
## Summary
- make the booking history admin page use the full available width with light horizontal padding
- add responsive padding adjustments for larger viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908027d62a883209bedc4bae23c716e