### PR TITLE
Adjust dashboard copy button layout

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -396,19 +396,17 @@
 
 .bokun-booking-dashboard__title-row {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.6rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   width: 100%;
 }
 
-.bokun-booking-dashboard__title-actions {
+.bokun-booking-dashboard__title-main {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  margin-left: auto;
+  align-items: baseline;
+  gap: 0.5rem;
 }
 
 .bokun-booking-dashboard__title {
@@ -429,8 +427,11 @@
 }
 
 .bokun-booking-dashboard__copy-button {
-  border: 0;
-  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  background: none;
   color: #2563eb;
   padding: 0;
   font-size: 0.75rem;
@@ -442,7 +443,7 @@
 
 .bokun-booking-dashboard__copy-button:hover,
 .bokun-booking-dashboard__copy-button:focus {
-  color: #1d4ed8;
+  color: #1e40af;
   text-decoration: underline;
   outline: none;
 }

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -803,42 +803,40 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 >
                     <header class="bokun-booking-dashboard__header">
                         <div class="bokun-booking-dashboard__title-row">
-                            <h3 class="bokun-booking-dashboard__title">
-                                <?php if (!empty($permalink)) : ?>
-                                    <a href="<?php echo esc_url($permalink); ?>" target="_blank" rel="noopener noreferrer">
-                                        <?php echo esc_html(get_the_title($post_id)); ?>
-                                    </a>
-                                <?php else : ?>
-                                    <?php echo esc_html(get_the_title($post_id)); ?>
-                                <?php endif; ?>
-                            </h3>
-                            <?php if (!empty($partner_page_url) || !empty($title_copy_value)) : ?>
-                                <div class="bokun-booking-dashboard__title-actions">
-                                    <?php if (!empty($partner_page_url)) : ?>
-                                        <a
-                                            class="bokun-booking-dashboard__reserve-link"
-                                            href="<?php echo esc_url($partner_page_url); ?>"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            <?php esc_html_e('Reserve link', 'BOKUN_txt_domain'); ?>
+                            <div class="bokun-booking-dashboard__title-main">
+                                <h3 class="bokun-booking-dashboard__title">
+                                    <?php if (!empty($permalink)) : ?>
+                                        <a href="<?php echo esc_url($permalink); ?>" target="_blank" rel="noopener noreferrer">
+                                            <?php echo esc_html(get_the_title($post_id)); ?>
                                         </a>
+                                    <?php else : ?>
+                                        <?php echo esc_html(get_the_title($post_id)); ?>
                                     <?php endif; ?>
-                                    <?php if (!empty($title_copy_value)) : ?>
-                                        <button
-                                            type="button"
-                                            class="bokun-booking-dashboard__copy-button"
-                                            data-copy-value="<?php echo esc_attr($title_copy_value); ?>"
-                                            <?php if (!empty($title_copy_html)) : ?>data-copy-html="<?php echo esc_attr($title_copy_html); ?>"<?php endif; ?>
-                                            data-copy-label="<?php esc_attr_e('Copy title & link', 'BOKUN_txt_domain'); ?>"
-                                            data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
-                                            data-copy-error="<?php esc_attr_e('Copy failed', 'BOKUN_txt_domain'); ?>"
-                                            data-copy-state="default"
-                                        >
-                                            <?php esc_html_e('Copy title & link', 'BOKUN_txt_domain'); ?>
-                                        </button>
-                                    <?php endif; ?>
-                                </div>
+                                </h3>
+                                <?php if (!empty($title_copy_value)) : ?>
+                                    <button
+                                        type="button"
+                                        class="bokun-booking-dashboard__copy-button"
+                                        data-copy-value="<?php echo esc_attr($title_copy_value); ?>"
+                                        <?php if (!empty($title_copy_html)) : ?>data-copy-html="<?php echo esc_attr($title_copy_html); ?>"<?php endif; ?>
+                                        data-copy-label="<?php esc_attr_e('Copy title & link', 'BOKUN_txt_domain'); ?>"
+                                        data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
+                                        data-copy-error="<?php esc_attr_e('Copy failed', 'BOKUN_txt_domain'); ?>"
+                                        data-copy-state="default"
+                                    >
+                                        <?php esc_html_e('Copy title & link', 'BOKUN_txt_domain'); ?>
+                                    </button>
+                                <?php endif; ?>
+                            </div>
+                            <?php if (!empty($partner_page_url)) : ?>
+                                <a
+                                    class="bokun-booking-dashboard__reserve-link"
+                                    href="<?php echo esc_url($partner_page_url); ?>"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    <?php esc_html_e('Reserve link', 'BOKUN_txt_domain'); ?>
+                                </a>
                             <?php endif; ?>
                         </div>
                         <?php if (!empty($vendor_title)) : ?>


### PR DESCRIPTION
## Summary
- place the booking title copy button alongside the title and move the reserve link onto its own line
- refresh dashboard copy button styling to remove borders/backgrounds and add a clearer hover state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690805387c088320ae0c4afb13e8c3a6