### PR TITLE
Adjust dashboard copy button styling

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -431,21 +431,34 @@
   align-items: center;
   gap: 0.25rem;
   border: none;
+  border-radius: 0;
   background: none;
+  background-color: transparent;
+  box-shadow: none;
   color: #2563eb;
   padding: 0;
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
-  transition: color 0.2s ease;
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+  appearance: none;
 }
 
 .bokun-booking-dashboard__copy-button:hover,
 .bokun-booking-dashboard__copy-button:focus {
-  color: #1e40af;
+  color: #1d4ed8;
   text-decoration: underline;
+  background: none;
+  background-color: transparent;
+  box-shadow: none;
   outline: none;
+}
+
+.bokun-booking-dashboard__copy-button:focus-visible {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
 }
 
 .bokun-booking-dashboard__copy-button[data-copy-state="copied"] {


### PR DESCRIPTION
## Summary
- ensure dashboard copy buttons render as text links without borders or backgrounds
- refine hover and focus styles so the buttons change color instead of relying on background changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690806b903a48320b4ef6096c10f6be8