### PR TITLE
Revamp dashboard controls and styling

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -124,6 +124,11 @@
   flex-direction: column;
   gap: 1.5rem;
   margin: 2rem 0;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid #e2e8f0;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
 }
 
 .bokun-booking-dashboard__controls {
@@ -131,6 +136,10 @@
   flex-wrap: wrap;
   gap: 1rem;
   align-items: flex-end;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: rgba(37, 99, 235, 0.06);
+  border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .bokun-booking-dashboard__search {
@@ -208,15 +217,15 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  padding: 0.55rem 2.25rem 0.55rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid #cbd5e1;
-  background: #ffffff;
-  font-size: 0.92rem;
+  padding: 0.65rem 2.5rem 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid #bfdbfe;
+  background: linear-gradient(135deg, #eff6ff 0%, #ffffff 100%);
+  font-size: 0.94rem;
   font-weight: 600;
-  color: #1e293b;
+  color: #1e3a8a;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .bokun-booking-dashboard__filter-dropdown summary::-webkit-details-marker {
@@ -225,19 +234,20 @@
 
 .bokun-booking-dashboard__filter-dropdown summary::after {
   content: "\25BE";
-  font-size: 0.65rem;
-  color: #475569;
+  font-size: 0.7rem;
+  color: #1e3a8a;
   position: absolute;
-  right: 0.85rem;
+  right: 1rem;
   top: 50%;
   transform: translateY(-50%);
   transition: transform 0.2s ease;
 }
 
 .bokun-booking-dashboard__filter-dropdown[open] summary {
-  border-color: #2563eb;
-  background: #eff6ff;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  border-color: #1d4ed8;
+  background: linear-gradient(135deg, #dbeafe 0%, #eff6ff 100%);
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.18);
+  transform: translateY(-1px);
 }
 
 .bokun-booking-dashboard__filter-dropdown[open] summary::after {
@@ -245,12 +255,12 @@
 }
 
 .bokun-booking-dashboard__filter-menu {
-  margin-top: 0.4rem;
-  border: 1px solid #cbd5e1;
-  border-radius: 0.75rem;
+  margin-top: 0.45rem;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.85rem;
   background: #ffffff;
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
-  padding: 0.75rem;
+  box-shadow: 0 22px 38px rgba(15, 23, 42, 0.12);
+  padding: 0.85rem;
 }
 
 .bokun-booking-dashboard__filter-options {
@@ -265,7 +275,7 @@
 .bokun-booking-dashboard__filter-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
   font-size: 0.9rem;
   color: #0f172a;
 }
@@ -279,8 +289,9 @@
 .bokun-booking-dashboard__filter-option input[type="checkbox"] {
   width: 1rem;
   height: 1rem;
-  border-radius: 0.25rem;
-  border: 1px solid #cbd5e1;
+  border-radius: 0.35rem;
+  border: 1px solid #bfdbfe;
+  accent-color: #2563eb;
 }
 
 .bokun-booking-dashboard__empty--filtered[hidden] {
@@ -297,22 +308,23 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.9rem;
+  padding: 0.55rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
-  color: #1e293b;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(59, 130, 246, 0.05) 100%);
+  color: #1e3a8a;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
 .bokun-booking-dashboard__tab[aria-selected="true"] {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  border-color: #1d4ed8;
   color: #ffffff;
-  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.3);
+  transform: translateY(-1px);
 }
 
 .bokun-booking-dashboard__tab:focus {
@@ -337,6 +349,7 @@
   font-weight: 600;
   line-height: 1;
   pointer-events: none;
+  transition: background 0.2s ease;
 }
 
 .bokun-booking-dashboard__panels {
@@ -429,31 +442,25 @@
 
 .bokun-booking-dashboard__copy-button {
   display: inline;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  background-color: transparent;
-  box-shadow: none;
-  color: #2563eb;
   padding: 0;
   margin: 0;
-  font-size: 0.75rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: #1d4ed8;
+  font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.02em;
   line-height: inherit;
   cursor: pointer;
   text-decoration: none;
-  transition: color 0.2s ease, text-decoration-color 0.2s ease;
-  appearance: none;
+  transition: color 0.2s ease;
 }
 
 .bokun-booking-dashboard__copy-button:hover,
 .bokun-booking-dashboard__copy-button:focus {
-  color: #1e3a8a;
+  color: #172554;
   text-decoration: underline;
-  background: transparent;
-  background-color: transparent;
-  box-shadow: none;
   outline: none;
 }
 
@@ -474,22 +481,24 @@
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  background: #2563eb;
+  background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);
   color: #ffffff;
-  padding: 0.35rem 0.9rem;
+  padding: 0.4rem 1rem;
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-decoration: none;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
 }
 
 .bokun-booking-dashboard__reserve-link:hover,
 .bokun-booking-dashboard__reserve-link:focus {
-  background: #1d4ed8;
+  background: linear-gradient(135deg, #1d4ed8 0%, #4338ca 100%);
   color: #ffffff;
   transform: translateY(-1px);
   outline: none;
+  box-shadow: 0 12px 28px rgba(29, 78, 216, 0.35);
 }
 
 .bokun-booking-dashboard__vendor {
@@ -510,10 +519,11 @@
 .bokun-booking-dashboard__status-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 0;
-  padding: 0;
+  gap: 0.4rem;
+  margin: 1.25rem 0 0;
+  padding: 1rem 0 0;
   list-style: none;
+  border-top: 1px solid #e2e8f0;
 }
 
 .bokun-booking-dashboard__body {
@@ -537,14 +547,14 @@
 }
 
 .bokun-booking-dashboard__status-item {
-  padding: 0.25rem 0.6rem;
+  padding: 0.2rem 0.5rem;
   border-radius: 999px;
-  background: #eff6ff;
+  background: #e0f2fe;
   color: #1d4ed8;
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.08em;
 }
 
 .bokun-booking-dashboard__details {
@@ -595,7 +605,7 @@
 }
 
 .bokun-booking-dashboard__date--attention {
-  color: #1a7f37;
+  color: #ca8a04;
 }
 
 .bokun-booking-dashboard__time {
@@ -637,6 +647,14 @@
   color: #0f172a;
 }
 
+.bokun-booking-dashboard__references {
+  margin-top: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px dashed #cbd5f5;
+  background: #f8fafc;
+}
+
 .bokun-booking-dashboard__reference-list {
   margin: 0;
   padding: 0;
@@ -674,15 +692,19 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid #e2e8f0;
+  margin-top: 1.25rem;
+  margin-bottom: -0.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
   align-items: center;
 }
 
 .bokun-booking-dashboard__toggle-label {
   font-size: 0.85rem;
-  font-weight: 600;
-  color: #1f2937;
+  font-weight: 700;
+  color: #0f172a;
 }
 
 .bokun-booking-dashboard__toggle {
@@ -690,7 +712,7 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.85rem;
-  color: #1f2937;
+  color: #0f172a;
   cursor: pointer;
 }
 
@@ -698,6 +720,7 @@
   width: 1rem;
   height: 1rem;
   cursor: pointer;
+  accent-color: #2563eb;
 }
 
 .bokun-booking-dashboard__footer {
@@ -722,14 +745,14 @@
 }
 
 .bokun-booking-dashboard__card.alarm_status-alarm {
-  border-color: #f97316;
+  border-color: #d63638;
 }
 
 .bokun-booking-dashboard__card.alarm_status-attention {
-  border-color: #facc15;
+  border-color: #ca8a04;
 }
 
 .bokun-booking-dashboard__card.alarm_status-ok {
-  border-color: #22c55e;
+  border-color: #0f172a;
 }
 

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -814,9 +814,10 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                     <?php endif; ?>
                                 </h3>
                                 <?php if (!empty($title_copy_value)) : ?>
-                                    <button
-                                        type="button"
+                                    <a
+                                        href="#"
                                         class="bokun-booking-dashboard__copy-button"
+                                        role="button"
                                         data-copy-value="<?php echo esc_attr($title_copy_value); ?>"
                                         <?php if (!empty($title_copy_html)) : ?>data-copy-html="<?php echo esc_attr($title_copy_html); ?>"<?php endif; ?>
                                         data-copy-label="<?php esc_attr_e('Copy title & link', 'BOKUN_txt_domain'); ?>"
@@ -825,7 +826,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                         data-copy-state="default"
                                     >
                                         <?php esc_html_e('Copy title & link', 'BOKUN_txt_domain'); ?>
-                                    </button>
+                                    </a>
                                 <?php endif; ?>
                             </div>
                             <?php if (!empty($partner_page_url)) : ?>
@@ -851,13 +852,25 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                         <?php endif; ?>
                     </header>
 
-                    <?php if (!empty($status_labels)) : ?>
-                        <ul class="bokun-booking-dashboard__status-list">
-                            <?php foreach ($status_labels as $status_label) : ?>
-                                <li class="bokun-booking-dashboard__status-item"><?php echo esc_html($status_label); ?></li>
-                            <?php endforeach; ?>
-                        </ul>
-                    <?php endif; ?>
+                    <div class="bokun-booking-dashboard__toggles" role="group" aria-label="<?php esc_attr_e('Booking status toggles', 'BOKUN_txt_domain'); ?>">
+                        <span class="bokun-booking-dashboard__toggle-label"><?php esc_html_e('Result:', 'BOKUN_txt_domain'); ?></span>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="full" <?php echo checked($checkbox_states['full'], true, false); ?> />
+                            <span><?php esc_html_e('Full', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="partial" <?php echo checked($checkbox_states['partial'], true, false); ?> />
+                            <span><?php esc_html_e('Partial', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="not-available" <?php echo checked($checkbox_states['not-available'], true, false); ?> />
+                            <span><?php esc_html_e('Not available', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                        <label class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="refund-partner" <?php echo checked($checkbox_states['refund-partner'], true, false); ?> />
+                            <span><?php esc_html_e('Refund requested', 'BOKUN_txt_domain'); ?></span>
+                        </label>
+                    </div>
 
                     <div class="bokun-booking-dashboard__body">
                         <?php if (!empty($product_title) || !empty($rate_title) || !empty($meeting_point) || !empty($start_date_display) || !empty($start_time_display) || !empty($participants) || !empty($inclusions)) : ?>
@@ -930,9 +943,10 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                 <dt><?php esc_html_e('Lead traveller', 'BOKUN_txt_domain'); ?></dt>
                                                 <dd class="bokun-booking-dashboard__detail-copy">
                                                     <span class="bokun-booking-dashboard__detail-value"><?php echo esc_html($customer_name); ?></span>
-                                                    <button
-                                                        type="button"
+                                                    <a
+                                                        href="#"
                                                         class="bokun-booking-dashboard__copy-button"
+                                                        role="button"
                                                         data-copy-value="<?php echo esc_attr($customer_name); ?>"
                                                         data-copy-label="<?php esc_attr_e('Copy', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
@@ -940,7 +954,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                         data-copy-state="default"
                                                     >
                                                         <?php esc_html_e('Copy', 'BOKUN_txt_domain'); ?>
-                                                    </button>
+                                                    </a>
                                                 </dd>
                                             </div>
                                         <?php endif; ?>
@@ -950,9 +964,10 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                 <dt><?php esc_html_e('First name', 'BOKUN_txt_domain'); ?></dt>
                                                 <dd class="bokun-booking-dashboard__detail-copy">
                                                     <span class="bokun-booking-dashboard__detail-value"><?php echo esc_html($customer_first); ?></span>
-                                                    <button
-                                                        type="button"
+                                                    <a
+                                                        href="#"
                                                         class="bokun-booking-dashboard__copy-button"
+                                                        role="button"
                                                         data-copy-value="<?php echo esc_attr($customer_first); ?>"
                                                         data-copy-label="<?php esc_attr_e('Copy', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
@@ -960,7 +975,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                         data-copy-state="default"
                                                     >
                                                         <?php esc_html_e('Copy', 'BOKUN_txt_domain'); ?>
-                                                    </button>
+                                                    </a>
                                                 </dd>
                                             </div>
                                         <?php endif; ?>
@@ -970,9 +985,10 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                 <dt><?php esc_html_e('Last name', 'BOKUN_txt_domain'); ?></dt>
                                                 <dd class="bokun-booking-dashboard__detail-copy">
                                                     <span class="bokun-booking-dashboard__detail-value"><?php echo esc_html($customer_last); ?></span>
-                                                    <button
-                                                        type="button"
+                                                    <a
+                                                        href="#"
                                                         class="bokun-booking-dashboard__copy-button"
+                                                        role="button"
                                                         data-copy-value="<?php echo esc_attr($customer_last); ?>"
                                                         data-copy-label="<?php esc_attr_e('Copy', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
@@ -980,7 +996,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                         data-copy-state="default"
                                                     >
                                                         <?php esc_html_e('Copy', 'BOKUN_txt_domain'); ?>
-                                                    </button>
+                                                    </a>
                                                 </dd>
                                             </div>
                                         <?php endif; ?>
@@ -990,9 +1006,10 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                 <dt><?php esc_html_e('Phone', 'BOKUN_txt_domain'); ?></dt>
                                                 <dd class="bokun-booking-dashboard__detail-copy">
                                                     <span class="bokun-booking-dashboard__detail-value"><?php echo esc_html($phone_display); ?></span>
-                                                    <button
-                                                        type="button"
+                                                    <a
+                                                        href="#"
                                                         class="bokun-booking-dashboard__copy-button"
+                                                        role="button"
                                                         data-copy-value="<?php echo esc_attr($phone_display); ?>"
                                                         data-copy-label="<?php esc_attr_e('Copy', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
@@ -1000,19 +1017,20 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                         data-copy-state="default"
                                                     >
                                                         <?php esc_html_e('Copy', 'BOKUN_txt_domain'); ?>
-                                                    </button>
+                                                    </a>
                                                 </dd>
                                             </div>
                                         <?php endif; ?>
 
                                         <?php if (!empty($external_ref)) : ?>
                                             <div class="bokun-booking-dashboard__detail">
-                                                <dt><?php esc_html_e('Reference', 'BOKUN_txt_domain'); ?></dt>
+                                                <dt><?php esc_html_e('Reference for booking:', 'BOKUN_txt_domain'); ?></dt>
                                                 <dd class="bokun-booking-dashboard__detail-copy">
                                                     <span class="bokun-booking-dashboard__detail-value"><?php echo esc_html($external_ref); ?></span>
-                                                    <button
-                                                        type="button"
+                                                    <a
+                                                        href="#"
                                                         class="bokun-booking-dashboard__copy-button"
+                                                        role="button"
                                                         data-copy-value="<?php echo esc_attr($external_ref); ?>"
                                                         data-copy-label="<?php esc_attr_e('Copy', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
@@ -1020,7 +1038,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                         data-copy-state="default"
                                                     >
                                                         <?php esc_html_e('Copy', 'BOKUN_txt_domain'); ?>
-                                                    </button>
+                                                    </a>
                                                 </dd>
                                             </div>
                                         <?php endif; ?>
@@ -1043,7 +1061,6 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
 
                                 <?php if (!empty($viator_url) || !empty($bokun_url)) : ?>
                                     <div class="bokun-booking-dashboard__references">
-                                        <h4 class="bokun-booking-dashboard__section-title"><?php esc_html_e('Reference for booking', 'BOKUN_txt_domain'); ?></h4>
                                         <ul class="bokun-booking-dashboard__reference-list">
                                             <?php if (!empty($viator_url)) : ?>
                                                 <li>
@@ -1068,25 +1085,13 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                         <?php endif; ?>
                     </div>
 
-                    <div class="bokun-booking-dashboard__toggles" role="group" aria-label="<?php esc_attr_e('Booking status toggles', 'BOKUN_txt_domain'); ?>">
-                        <span class="bokun-booking-dashboard__toggle-label"><?php esc_html_e('Result:', 'BOKUN_txt_domain'); ?></span>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="full" <?php echo checked($checkbox_states['full'], true, false); ?> />
-                            <span><?php esc_html_e('Full', 'BOKUN_txt_domain'); ?></span>
-                        </label>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="partial" <?php echo checked($checkbox_states['partial'], true, false); ?> />
-                            <span><?php esc_html_e('Partial', 'BOKUN_txt_domain'); ?></span>
-                        </label>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="not-available" <?php echo checked($checkbox_states['not-available'], true, false); ?> />
-                            <span><?php esc_html_e('Not available', 'BOKUN_txt_domain'); ?></span>
-                        </label>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="refund-partner" <?php echo checked($checkbox_states['refund-partner'], true, false); ?> />
-                            <span><?php esc_html_e('Refund requested', 'BOKUN_txt_domain'); ?></span>
-                        </label>
-                    </div>
+                    <?php if (!empty($status_labels)) : ?>
+                        <ul class="bokun-booking-dashboard__status-list">
+                            <?php foreach ($status_labels as $status_label) : ?>
+                                <li class="bokun-booking-dashboard__status-item"><?php echo esc_html($status_label); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
 
                 </article>
                 <?php
@@ -1652,6 +1657,13 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                         button.addEventListener('click', function (event) {
                             event.preventDefault();
                             copyValue(button);
+                        });
+
+                        button.addEventListener('keydown', function (event) {
+                            if (event.key === ' ' || event.key === 'Spacebar') {
+                                event.preventDefault();
+                                copyValue(button);
+                            }
                         });
                     });
 


### PR DESCRIPTION
## Summary
- replace dashboard copy buttons with accessible text links and move the result toggles above booking details
- restyle dashboard container, filters, and action controls while resizing and relocating booking tags
- align booking card borders with status colours and refresh reference and copy interactions

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_690815fc889c8320bb79f22f2ab129ed