### PR TITLE
Enhance booking dashboard utilities and styling

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -131,6 +131,48 @@
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
 }
 
+.bokun-booking-dashboard__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.bokun-booking-dashboard__toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bokun-booking-dashboard__toolbar-group--right {
+  margin-left: auto;
+}
+
+.bokun-booking-dashboard__toolbar-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bokun-booking-dashboard__toolbar-link:hover,
+.bokun-booking-dashboard__toolbar-link:focus {
+  color: #0f172a;
+  background: rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
+  outline: none;
+}
+
 .bokun-booking-dashboard__controls {
   display: flex;
   flex-wrap: wrap;
@@ -187,6 +229,7 @@
   cursor: pointer;
   padding: 0.2rem;
   border-radius: 999px;
+  text-decoration: none;
   transition: color 0.2s ease, background-color 0.2s ease;
 }
 
@@ -316,6 +359,7 @@
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
+  text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
@@ -519,11 +563,30 @@
 .bokun-booking-dashboard__status-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-  margin: 1.25rem 0 0;
-  padding: 1rem 0 0;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
   list-style: none;
+}
+
+.bokun-booking-dashboard__meta-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+  padding-top: 0.75rem;
   border-top: 1px solid #e2e8f0;
+}
+
+.bokun-booking-dashboard__reference-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.75rem;
+  color: #475569;
 }
 
 .bokun-booking-dashboard__body {
@@ -547,14 +610,47 @@
 }
 
 .bokun-booking-dashboard__status-item {
-  padding: 0.2rem 0.5rem;
+  padding: 0.2rem 0.45rem;
   border-radius: 999px;
   background: #e0f2fe;
   color: #1d4ed8;
-  font-size: 0.68rem;
-  font-weight: 600;
+  font-size: 0.6rem;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  line-height: 1.4;
+}
+
+.bokun-booking-dashboard__status-grid {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.bokun-booking-dashboard__status-grid-item {
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.2);
+}
+
+.bokun-booking-dashboard__status-grid-label {
+  display: block;
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #1d4ed8;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.bokun-booking-dashboard__status-grid-text {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: #1f2937;
 }
 
 .bokun-booking-dashboard__details {
@@ -647,39 +743,28 @@
   color: #0f172a;
 }
 
-.bokun-booking-dashboard__references {
-  margin-top: 0.75rem;
-  padding: 0.75rem 0.85rem;
-  border-radius: 0.75rem;
-  border: 1px dashed #cbd5f5;
-  background: #f8fafc;
-}
-
-.bokun-booking-dashboard__reference-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.bokun-booking-dashboard__reference-label {
-  font-weight: 600;
-  color: #1f2937;
-  margin-right: 0.4rem;
-}
-
 .bokun-booking-dashboard__reference-link {
-  color: #2563eb;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
   font-weight: 600;
+  font-size: 0.75rem;
   text-decoration: none;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .bokun-booking-dashboard__reference-link:hover,
 .bokun-booking-dashboard__reference-link:focus {
-  color: #1d4ed8;
-  text-decoration: underline;
+  color: #0f172a;
+  background: rgba(59, 130, 246, 0.22);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
+  outline: none;
 }
 
 .bokun-booking-dashboard__inclusions p {
@@ -721,6 +806,154 @@
   height: 1rem;
   cursor: pointer;
   accent-color: #2563eb;
+}
+
+.bokun-booking-dashboard__conversations {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 100%);
+  padding: 1.75rem 1.5rem;
+  background: #ffffff;
+  border-left: 1px solid #e2e8f0;
+  box-shadow: -18px 0 36px rgba(15, 23, 42, 0.18);
+  overflow-y: auto;
+  z-index: 999;
+}
+
+.bokun-booking-dashboard__conversations-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.bokun-booking-dashboard__conversations-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__conversations-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  color: #475569;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.bokun-booking-dashboard__conversations-close:hover,
+.bokun-booking-dashboard__conversations-close:focus {
+  color: #0f172a;
+  background: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  outline: none;
+}
+
+.bokun-booking-dashboard__conversations-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.bokun-booking-dashboard__conversation h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.bokun-booking-dashboard__conversation p {
+  margin: 0.35rem 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #1f2937;
+}
+
+.bokun-booking-dashboard__conversation a {
+  color: #1d4ed8;
+  text-decoration: underline;
+  word-break: break-word;
+}
+
+.bokun-booking-dashboard__conversation a:hover,
+.bokun-booking-dashboard__conversation a:focus {
+  color: #0f172a;
+}
+
+@media (max-width: 768px) {
+  .bokun-booking-dashboard__conversations {
+    width: 100%;
+  }
+}
+
+.bokun-booking-dashboard__missing-tags {
+  margin-top: 2rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  box-shadow: 0 18px 36px rgba(148, 163, 184, 0.18);
+}
+
+.bokun-booking-dashboard__missing-tags h3 {
+  margin: 0 0 0.85rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__missing-tags-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.bokun-booking-dashboard__missing-tags-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+
+.bokun-booking-dashboard__missing-tag-name {
+  font-weight: 600;
+}
+
+.bokun-booking-dashboard__missing-tag-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(37, 99, 235, 0.28);
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bokun-booking-dashboard__missing-tag-link:hover,
+.bokun-booking-dashboard__missing-tag-link:focus {
+  color: #0f172a;
+  background: rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  outline: none;
 }
 
 .bokun-booking-dashboard__footer {


### PR DESCRIPTION
## Summary
- replace dashboard buttons with accessible links and add a fetch/common conversations toolbar with a right-side template drawer
- streamline booking cards by inlining partner links, shrinking status pills, and showing contextual status guidance
- surface product tags without partner links and refresh front-end styles to match the new layout

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_69082f46e4108320943d989d3c2006ad