### PR TITLE
Add refund follow-up section and improve booking dashboard UI

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -562,11 +562,21 @@
 
 .bokun-booking-dashboard__status-list {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
+  flex-wrap: nowrap;
+  gap: 0.25rem;
   margin: 0;
   padding: 0;
   list-style: none;
+  overflow-x: auto;
+}
+
+.bokun-booking-dashboard__status-list::-webkit-scrollbar {
+  height: 6px;
+}
+
+.bokun-booking-dashboard__status-list::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.5);
+  border-radius: 999px;
 }
 
 .bokun-booking-dashboard__meta-line {
@@ -574,19 +584,20 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  margin-top: 1.25rem;
-  padding-top: 0.75rem;
+  gap: 0.5rem;
+  margin-top: 1.1rem;
+  padding-top: 0.65rem;
   border-top: 1px solid #e2e8f0;
 }
 
 .bokun-booking-dashboard__reference-links {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
   align-items: center;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: #475569;
+  white-space: nowrap;
 }
 
 .bokun-booking-dashboard__body {
@@ -610,15 +621,15 @@
 }
 
 .bokun-booking-dashboard__status-item {
-  padding: 0.2rem 0.45rem;
+  padding: 0.15rem 0.4rem;
   border-radius: 999px;
   background: #e0f2fe;
   color: #1d4ed8;
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  line-height: 1.4;
+  line-height: 1.35;
 }
 
 .bokun-booking-dashboard__status-grid {
@@ -634,6 +645,36 @@
   border: 1px solid #dbeafe;
   background: #f8fbff;
   box-shadow: 0 12px 24px rgba(148, 163, 184, 0.2);
+}
+
+.bokun-booking-dashboard__dual-status {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bokun-booking-dashboard__dual-status-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__dual-status-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.bokun-booking-dashboard__dual-status-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .bokun-booking-dashboard__status-grid-label {
@@ -773,13 +814,23 @@
   color: #334155;
 }
 
+.bokun-booking-dashboard__pre-toggle-note {
+  margin: 0.75rem 0 0;
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.bokun-booking-dashboard__pre-toggle-note strong {
+  font-weight: 600;
+}
+
 .bokun-booking-dashboard__toggles {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 1.25rem;
-  margin-bottom: -0.25rem;
-  padding: 0.85rem 1rem;
+  gap: 0.6rem;
+  margin-top: 0.6rem;
+  margin-bottom: 0.35rem;
+  padding: 0.7rem 0.85rem;
   border-radius: 0.85rem;
   background: #f1f5f9;
   border: 1px solid #e2e8f0;
@@ -806,6 +857,13 @@
   height: 1rem;
   cursor: pointer;
   accent-color: #2563eb;
+}
+
+.bokun-booking-dashboard__conversations-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  z-index: 998;
 }
 
 .bokun-booking-dashboard__conversations {
@@ -841,13 +899,15 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 3rem;
+  height: 3rem;
   border-radius: 999px;
-  color: #475569;
+  color: #1f2937;
   text-decoration: none;
-  border: 1px solid transparent;
-  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+  border: 2px solid transparent;
+  font-size: 1.75rem;
+  font-weight: 700;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .bokun-booking-dashboard__conversations-close:hover,
@@ -856,6 +916,7 @@
   background: rgba(148, 163, 184, 0.15);
   border-color: rgba(148, 163, 184, 0.35);
   outline: none;
+  transform: scale(1.05);
 }
 
 .bokun-booking-dashboard__conversations-body {


### PR DESCRIPTION
## Summary
- remove the "Confirmed" status guidance and add a reminder note above the result toggles
- show the refund toggle only for bookings tagged both "Booking made" and "Cancelled" and surface those bookings in a dedicated section
- tighten the reference link/tag styling and improve the common conversations popup with a large close button and backdrop

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_690838545c3c8320bd037f1b3eed4a67