### PR TITLE
Add booking history modal and dual-status summary

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -658,11 +658,70 @@
   gap: 1rem;
 }
 
+.bokun-booking-dashboard__dual-status-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.bokun-booking-dashboard__dual-status-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
 .bokun-booking-dashboard__dual-status-title {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 700;
   color: #0f172a;
+}
+
+.bokun-booking-dashboard__dual-status-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.28);
+}
+
+.bokun-booking-dashboard__dual-status-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.bokun-booking-dashboard__dual-status-toggle:hover,
+.bokun-booking-dashboard__dual-status-toggle:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.26);
+  outline: none;
+}
+
+.bokun-booking-dashboard__dual-status-toggle.is-active {
+  background: linear-gradient(135deg, #1e3a8a, #1d4ed8);
+}
+
+.bokun-booking-dashboard__dual-status-toggle:focus-visible {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.45);
 }
 
 .bokun-booking-dashboard__dual-status-description {
@@ -692,6 +751,130 @@
   font-size: 0.78rem;
   line-height: 1.45;
   color: #1f2937;
+}
+
+.bokun-booking-dashboard__history-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 1002;
+}
+
+.bokun-booking-dashboard__history {
+  position: fixed;
+  bottom: 8vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(960px, 92vw);
+  max-height: 80vh;
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 28px 56px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  z-index: 1003;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.bokun-booking-dashboard__history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.bokun-booking-dashboard__history-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__history-close {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.bokun-booking-dashboard__history-close:hover,
+.bokun-booking-dashboard__history-close:focus {
+  color: #0f172a;
+  background: rgba(226, 232, 240, 0.65);
+  outline: none;
+}
+
+.bokun-booking-dashboard__history-body {
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.bokun-booking-dashboard__history-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.bokun-booking-dashboard__corner {
+  position: fixed;
+  bottom: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  font-size: 0.85rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.3);
+  z-index: 1001;
+}
+
+.bokun-booking-dashboard__corner--left {
+  left: 1.5rem;
+}
+
+.bokun-booking-dashboard__corner--right {
+  right: 1.5rem;
+}
+
+.bokun-booking-dashboard__corner-label {
+  font-weight: 600;
+}
+
+.bokun-booking-dashboard__corner-value {
+  font-weight: 500;
+}
+
+.bokun-booking-dashboard__history-launch {
+  border: none;
+  background: linear-gradient(135deg, #059669, #10b981);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 28px rgba(16, 185, 129, 0.35);
+}
+
+.bokun-booking-dashboard__history-launch:hover,
+.bokun-booking-dashboard__history-launch:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px rgba(16, 185, 129, 0.4);
+  outline: none;
+}
+
+.bokun-booking-dashboard__history-launch:focus-visible {
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.45);
 }
 
 .bokun-booking-dashboard__details {
@@ -815,7 +998,7 @@
 }
 
 .bokun-booking-dashboard__pre-toggle-note {
-  margin: 0.75rem 0 0;
+  margin: 0;
   font-size: 0.75rem;
   color: #475569;
 }
@@ -828,8 +1011,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
-  margin-top: 0.6rem;
-  margin-bottom: 0.35rem;
+  margin: 0;
   padding: 0.7rem 0.85rem;
   border-radius: 0.85rem;
   background: #f1f5f9;
@@ -953,6 +1135,25 @@
 @media (max-width: 768px) {
   .bokun-booking-dashboard__conversations {
     width: 100%;
+  }
+
+  .bokun-booking-dashboard__corner {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+
+  .bokun-booking-dashboard__corner--left {
+    bottom: 4.25rem;
+  }
+
+  .bokun-booking-dashboard__corner--right {
+    bottom: 1.5rem;
+  }
+
+  .bokun-booking-dashboard__history {
+    width: 94vw;
+    bottom: 6vh;
   }
 }
 

--- a/assets/js/bokun_front.js
+++ b/assets/js/bokun_front.js
@@ -717,5 +717,154 @@ jQuery(function ($) {
                 }
         }
 
+        function toggleDualStatusSection(button) {
+                var $button = $(button);
+                var $section = $button.closest('[data-dashboard-dual-status]');
+
+                if (!$section.length) {
+                        return;
+                }
+
+                var $panel = $section.find('[data-dashboard-dual-status-panel]').first();
+                var isExpanded = $button.attr('aria-expanded') === 'true';
+                var nextState = !isExpanded;
+                var showLabel = $button.data('showLabel') || $button.attr('data-show-label') || '';
+                var hideLabel = $button.data('hideLabel') || $button.attr('data-hide-label') || '';
+                var targetLabel = nextState ? (hideLabel || 'Hide bookings') : (showLabel || 'Show bookings');
+
+                $button.attr('aria-expanded', nextState ? 'true' : 'false');
+                $button.toggleClass('is-active', nextState);
+
+                if ($panel.length) {
+                        if (nextState) {
+                                $panel.removeAttr('hidden');
+                        } else {
+                                $panel.attr('hidden', 'hidden');
+                        }
+                }
+
+                $button.text(targetLabel);
+        }
+
+        function getHistoryContext($dashboard) {
+                if (!$dashboard || !$dashboard.length) {
+                        return null;
+                }
+
+                var $overlay = $dashboard.find('[data-dashboard-history-overlay]').first();
+                var $dialog = $dashboard.find('[data-dashboard-history]').first();
+
+                if (!$overlay.length || !$dialog.length) {
+                        return null;
+                }
+
+                return {
+                        dashboard: $dashboard,
+                        overlay: $overlay,
+                        dialog: $dialog,
+                        trigger: $dashboard.data('historyTrigger')
+                };
+        }
+
+        function openHistoryDialog(button) {
+                var $button = $(button);
+                var $dashboard = $button.closest('.bokun-booking-dashboard');
+
+                if (!$dashboard.length) {
+                        return;
+                }
+
+                var context = getHistoryContext($dashboard);
+
+                if (!context) {
+                        return;
+                }
+
+                context.overlay.removeAttr('hidden').attr('aria-hidden', 'false');
+                context.dialog.removeAttr('hidden').attr('aria-hidden', 'false');
+                $dashboard.addClass('bokun-booking-dashboard--history-open');
+                $dashboard.data('historyTrigger', $button);
+                $button.attr('aria-expanded', 'true');
+
+                var $focusTarget = context.dialog.find('[data-dashboard-history-close]').first();
+
+                if (!$focusTarget.length) {
+                        $focusTarget = context.dialog;
+                }
+
+                setTimeout(function () {
+                        $focusTarget.trigger('focus');
+                }, 0);
+        }
+
+        function closeHistoryDialog(element) {
+                var $dashboard;
+
+                if (element && element.jquery) {
+                        $dashboard = element;
+                } else {
+                        $dashboard = $(element).closest('.bokun-booking-dashboard');
+                }
+
+                if (!$dashboard.length) {
+                        return;
+                }
+
+                var context = getHistoryContext($dashboard);
+
+                if (!context) {
+                        return;
+                }
+
+                context.overlay.attr('hidden', 'hidden').attr('aria-hidden', 'true');
+                context.dialog.attr('hidden', 'hidden').attr('aria-hidden', 'true');
+
+                var $trigger = context.trigger && context.trigger.length ? context.trigger : $dashboard.find('[data-dashboard-history-open]').first();
+
+                if ($trigger && $trigger.length) {
+                        $trigger.attr('aria-expanded', 'false');
+                }
+
+                $dashboard.removeClass('bokun-booking-dashboard--history-open');
+                $dashboard.removeData('historyTrigger');
+
+                if ($trigger && $trigger.length) {
+                        setTimeout(function () {
+                                $trigger.trigger('focus');
+                        }, 0);
+                }
+        }
+
+        $(document).on('click', '[data-dashboard-dual-status-toggle]', function (event) {
+                event.preventDefault();
+                toggleDualStatusSection(this);
+        });
+
+        $(document).on('click', '[data-dashboard-history-open]', function (event) {
+                event.preventDefault();
+                openHistoryDialog(this);
+        });
+
+        $(document).on('click', '[data-dashboard-history-close]', function (event) {
+                event.preventDefault();
+                closeHistoryDialog(this);
+        });
+
+        $(document).on('click', '[data-dashboard-history-overlay]', function (event) {
+                event.preventDefault();
+                closeHistoryDialog(this);
+        });
+
+        $(document).on('keydown', function (event) {
+                if (event.key === 'Escape' || event.key === 'Esc' || event.keyCode === 27) {
+                        var $openDashboard = $('.bokun-booking-dashboard--history-open').last();
+
+                        if ($openDashboard.length) {
+                                event.preventDefault();
+                                closeHistoryDialog($openDashboard);
+                        }
+                }
+        });
+
 
 });


### PR DESCRIPTION
## Summary
- add a collapsible "booking made & cancelled" section with a live count outside the tabbed grid
- surface the logged-in user name and a booking history modal trigger anchored to the dashboard corners
- tidy spacing around the pre-toggle notice, drop the cancelled guidance copy, and wire up the new UI with styling and scripts

## Testing
- php -l includes/bokun_shortcode.class.php


------
https://chatgpt.com/codex/tasks/task_e_69083fd519708320acda3febd419f5d5