### PR TITLE
Adjust dashboard footer indicators

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -658,11 +658,70 @@
   gap: 1rem;
 }
 
+.bokun-booking-dashboard__dual-status-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.bokun-booking-dashboard__dual-status-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
 .bokun-booking-dashboard__dual-status-title {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 700;
   color: #0f172a;
+}
+
+.bokun-booking-dashboard__dual-status-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.28);
+}
+
+.bokun-booking-dashboard__dual-status-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.bokun-booking-dashboard__dual-status-toggle:hover,
+.bokun-booking-dashboard__dual-status-toggle:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.26);
+  outline: none;
+}
+
+.bokun-booking-dashboard__dual-status-toggle.is-active {
+  background: linear-gradient(135deg, #1e3a8a, #1d4ed8);
+}
+
+.bokun-booking-dashboard__dual-status-toggle:focus-visible {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.45);
 }
 
 .bokun-booking-dashboard__dual-status-description {
@@ -692,6 +751,136 @@
   font-size: 0.78rem;
   line-height: 1.45;
   color: #1f2937;
+}
+
+.bokun-booking-dashboard__history-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 1002;
+}
+
+.bokun-booking-dashboard__history {
+  position: fixed;
+  bottom: 8vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(960px, 92vw);
+  max-height: 80vh;
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 28px 56px rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+  z-index: 1003;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.bokun-booking-dashboard__history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.bokun-booking-dashboard__history-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.bokun-booking-dashboard__history-close {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.bokun-booking-dashboard__history-close:hover,
+.bokun-booking-dashboard__history-close:focus {
+  color: #0f172a;
+  background: rgba(226, 232, 240, 0.65);
+  outline: none;
+}
+
+.bokun-booking-dashboard__history-body {
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.bokun-booking-dashboard__history-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+
+.bokun-booking-dashboard__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.bokun-booking-dashboard__footer-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #0f172a;
+  background: rgba(226, 232, 240, 0.4);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+}
+
+.bokun-booking-dashboard__footer-label {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.bokun-booking-dashboard__footer-value {
+  font-weight: 500;
+}
+
+.bokun-booking-dashboard__footer-item--history {
+  margin-left: auto;
+}
+
+.bokun-booking-dashboard__history-launch {
+  border: none;
+  background: linear-gradient(135deg, #059669, #10b981);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 16px 28px rgba(16, 185, 129, 0.35);
+}
+
+.bokun-booking-dashboard__history-launch:hover,
+.bokun-booking-dashboard__history-launch:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px rgba(16, 185, 129, 0.4);
+  outline: none;
+}
+
+.bokun-booking-dashboard__history-launch:focus-visible {
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.45);
 }
 
 .bokun-booking-dashboard__details {
@@ -815,7 +1004,7 @@
 }
 
 .bokun-booking-dashboard__pre-toggle-note {
-  margin: 0.75rem 0 0;
+  margin: 0;
   font-size: 0.75rem;
   color: #475569;
 }
@@ -828,8 +1017,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
-  margin-top: 0.6rem;
-  margin-bottom: 0.35rem;
+  margin: 0;
   padding: 0.7rem 0.85rem;
   border-radius: 0.85rem;
   background: #f1f5f9;
@@ -953,6 +1141,23 @@
 @media (max-width: 768px) {
   .bokun-booking-dashboard__conversations {
     width: 100%;
+  }
+
+  .bokun-booking-dashboard__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .bokun-booking-dashboard__footer-item,
+  .bokun-booking-dashboard__footer-item--history {
+    width: 100%;
+    justify-content: center;
+    margin-left: 0;
+  }
+
+  .bokun-booking-dashboard__history {
+    width: 94vw;
+    bottom: 6vh;
   }
 }
 

--- a/assets/js/bokun_front.js
+++ b/assets/js/bokun_front.js
@@ -717,5 +717,154 @@ jQuery(function ($) {
                 }
         }
 
+        function toggleDualStatusSection(button) {
+                var $button = $(button);
+                var $section = $button.closest('[data-dashboard-dual-status]');
+
+                if (!$section.length) {
+                        return;
+                }
+
+                var $panel = $section.find('[data-dashboard-dual-status-panel]').first();
+                var isExpanded = $button.attr('aria-expanded') === 'true';
+                var nextState = !isExpanded;
+                var showLabel = $button.data('showLabel') || $button.attr('data-show-label') || '';
+                var hideLabel = $button.data('hideLabel') || $button.attr('data-hide-label') || '';
+                var targetLabel = nextState ? (hideLabel || 'Hide bookings') : (showLabel || 'Show bookings');
+
+                $button.attr('aria-expanded', nextState ? 'true' : 'false');
+                $button.toggleClass('is-active', nextState);
+
+                if ($panel.length) {
+                        if (nextState) {
+                                $panel.removeAttr('hidden');
+                        } else {
+                                $panel.attr('hidden', 'hidden');
+                        }
+                }
+
+                $button.text(targetLabel);
+        }
+
+        function getHistoryContext($dashboard) {
+                if (!$dashboard || !$dashboard.length) {
+                        return null;
+                }
+
+                var $overlay = $dashboard.find('[data-dashboard-history-overlay]').first();
+                var $dialog = $dashboard.find('[data-dashboard-history]').first();
+
+                if (!$overlay.length || !$dialog.length) {
+                        return null;
+                }
+
+                return {
+                        dashboard: $dashboard,
+                        overlay: $overlay,
+                        dialog: $dialog,
+                        trigger: $dashboard.data('historyTrigger')
+                };
+        }
+
+        function openHistoryDialog(button) {
+                var $button = $(button);
+                var $dashboard = $button.closest('.bokun-booking-dashboard');
+
+                if (!$dashboard.length) {
+                        return;
+                }
+
+                var context = getHistoryContext($dashboard);
+
+                if (!context) {
+                        return;
+                }
+
+                context.overlay.removeAttr('hidden').attr('aria-hidden', 'false');
+                context.dialog.removeAttr('hidden').attr('aria-hidden', 'false');
+                $dashboard.addClass('bokun-booking-dashboard--history-open');
+                $dashboard.data('historyTrigger', $button);
+                $button.attr('aria-expanded', 'true');
+
+                var $focusTarget = context.dialog.find('[data-dashboard-history-close]').first();
+
+                if (!$focusTarget.length) {
+                        $focusTarget = context.dialog;
+                }
+
+                setTimeout(function () {
+                        $focusTarget.trigger('focus');
+                }, 0);
+        }
+
+        function closeHistoryDialog(element) {
+                var $dashboard;
+
+                if (element && element.jquery) {
+                        $dashboard = element;
+                } else {
+                        $dashboard = $(element).closest('.bokun-booking-dashboard');
+                }
+
+                if (!$dashboard.length) {
+                        return;
+                }
+
+                var context = getHistoryContext($dashboard);
+
+                if (!context) {
+                        return;
+                }
+
+                context.overlay.attr('hidden', 'hidden').attr('aria-hidden', 'true');
+                context.dialog.attr('hidden', 'hidden').attr('aria-hidden', 'true');
+
+                var $trigger = context.trigger && context.trigger.length ? context.trigger : $dashboard.find('[data-dashboard-history-open]').first();
+
+                if ($trigger && $trigger.length) {
+                        $trigger.attr('aria-expanded', 'false');
+                }
+
+                $dashboard.removeClass('bokun-booking-dashboard--history-open');
+                $dashboard.removeData('historyTrigger');
+
+                if ($trigger && $trigger.length) {
+                        setTimeout(function () {
+                                $trigger.trigger('focus');
+                        }, 0);
+                }
+        }
+
+        $(document).on('click', '[data-dashboard-dual-status-toggle]', function (event) {
+                event.preventDefault();
+                toggleDualStatusSection(this);
+        });
+
+        $(document).on('click', '[data-dashboard-history-open]', function (event) {
+                event.preventDefault();
+                openHistoryDialog(this);
+        });
+
+        $(document).on('click', '[data-dashboard-history-close]', function (event) {
+                event.preventDefault();
+                closeHistoryDialog(this);
+        });
+
+        $(document).on('click', '[data-dashboard-history-overlay]', function (event) {
+                event.preventDefault();
+                closeHistoryDialog(this);
+        });
+
+        $(document).on('keydown', function (event) {
+                if (event.key === 'Escape' || event.key === 'Esc' || event.keyCode === 27) {
+                        var $openDashboard = $('.bokun-booking-dashboard--history-open').last();
+
+                        if ($openDashboard.length) {
+                                event.preventDefault();
+                                closeHistoryDialog($openDashboard);
+                        }
+                }
+        });
+
 
 });

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -525,6 +525,17 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
             $days    = max(1, absint($atts['days']));
             $columns = max(1, min(6, absint($atts['columns'])));
 
+            $current_user      = wp_get_current_user();
+            $user_display_name = '';
+
+            if ($current_user instanceof WP_User && $current_user->exists()) {
+                $user_display_name = $current_user->display_name ?: $current_user->user_login;
+            }
+
+            if ('' === $user_display_name) {
+                $user_display_name = __('Guest user', 'BOKUN_txt_domain');
+            }
+
             $now_timestamp = current_time('timestamp');
             $range_end     = strtotime('+' . $days . ' days', $now_timestamp);
 
@@ -600,7 +611,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 ],
                 'cancelled' => [
                     'title'       => __('Cancelled', 'BOKUN_txt_domain'),
-                    'description' => __('Booked from partner but cancelled by client: need to cancel this reservation on partner website, or emailing them to ask for cancellation.', 'BOKUN_txt_domain'),
+                    'description' => '',
                 ],
             ];
 
@@ -1150,10 +1161,14 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
 
                     <?php if (!empty($status_guidance_entries)) : ?>
                         <div class="bokun-booking-dashboard__status-grid" role="group" aria-label="<?php esc_attr_e('Booking status guidance', 'BOKUN_txt_domain'); ?>">
-                            <?php foreach ($status_guidance_entries as $guidance_entry) : ?>
+                            <?php foreach ($status_guidance_entries as $guidance_entry) :
+                                $guidance_description = isset($guidance_entry['description']) ? trim((string) $guidance_entry['description']) : '';
+                                ?>
                                 <div class="bokun-booking-dashboard__status-grid-item">
                                     <span class="bokun-booking-dashboard__status-grid-label"><?php echo esc_html($guidance_entry['title']); ?></span>
-                                    <p class="bokun-booking-dashboard__status-grid-text"><?php echo esc_html($guidance_entry['description']); ?></p>
+                                    <?php if ($guidance_description !== '') : ?>
+                                        <p class="bokun-booking-dashboard__status-grid-text"><?php echo esc_html($guidance_description); ?></p>
+                                    <?php endif; ?>
                                 </div>
                             <?php endforeach; ?>
                         </div>
@@ -1213,6 +1228,19 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
             if ($should_render_progress) {
                 define('BOKUN_PROGRESS_RENDERED', true);
             }
+
+            $dual_status_count   = count($booking_made_cancelled_cards);
+            $history_markup      = $this->render_booking_history_table([
+                'limit'      => 150,
+                'capability' => '',
+                'export'     => 'dashboard-history',
+            ]);
+            $dual_status_section_id = $dashboard_id . '-dual-status';
+            $dual_status_panel_id   = $dashboard_id . '-dual-status-panel';
+            $dual_status_toggle_id  = $dashboard_id . '-dual-status-toggle';
+            $history_overlay_id     = $dashboard_id . '-history-overlay';
+            $history_dialog_id      = $dashboard_id . '-history-dialog';
+            $history_title_id       = $dashboard_id . '-history-title';
 
             ob_start();
             ?>
@@ -1390,15 +1418,47 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                         </div>
                     <?php endforeach; ?>
                 </div>
-                <?php if (!empty($booking_made_cancelled_cards)) : ?>
-                    <section class="bokun-booking-dashboard__dual-status" aria-labelledby="<?php echo esc_attr($dashboard_id); ?>-dual-status-title">
-                        <h3 id="<?php echo esc_attr($dashboard_id); ?>-dual-status-title" class="bokun-booking-dashboard__dual-status-title">
-                            <?php esc_html_e('Bookings tagged “Booking made” and “Cancelled”', 'BOKUN_txt_domain'); ?>
-                        </h3>
+                <?php if ($dual_status_count > 0) :
+                    $dual_status_show_label = __('Show bookings', 'BOKUN_txt_domain');
+                    $dual_status_hide_label = __('Hide bookings', 'BOKUN_txt_domain');
+                    ?>
+                    <section
+                        id="<?php echo esc_attr($dual_status_section_id); ?>"
+                        class="bokun-booking-dashboard__dual-status"
+                        aria-labelledby="<?php echo esc_attr($dual_status_section_id); ?>-title"
+                        data-dashboard-dual-status
+                    >
+                        <div class="bokun-booking-dashboard__dual-status-header">
+                            <div class="bokun-booking-dashboard__dual-status-heading">
+                                <h3 id="<?php echo esc_attr($dual_status_section_id); ?>-title" class="bokun-booking-dashboard__dual-status-title">
+                                    <?php esc_html_e('Bookings tagged “Booking made” and “Cancelled”', 'BOKUN_txt_domain'); ?>
+                                </h3>
+                                <span class="bokun-booking-dashboard__dual-status-count" aria-label="<?php esc_attr_e('Total bookings with both statuses', 'BOKUN_txt_domain'); ?>">
+                                    <?php echo esc_html(number_format_i18n($dual_status_count)); ?>
+                                </span>
+                            </div>
+                            <button
+                                type="button"
+                                class="bokun-booking-dashboard__dual-status-toggle"
+                                id="<?php echo esc_attr($dual_status_toggle_id); ?>"
+                                data-dashboard-dual-status-toggle
+                                data-show-label="<?php echo esc_attr($dual_status_show_label); ?>"
+                                data-hide-label="<?php echo esc_attr($dual_status_hide_label); ?>"
+                                aria-expanded="false"
+                                aria-controls="<?php echo esc_attr($dual_status_panel_id); ?>"
+                            >
+                                <?php echo esc_html($dual_status_show_label); ?>
+                            </button>
+                        </div>
                         <p class="bokun-booking-dashboard__dual-status-description">
-                            <?php esc_html_e('Review these bookings to make sure refunds and partner updates are completed.', 'BOKUN_txt_domain'); ?>
+                            <?php esc_html_e('Use this list to confirm partner cancellations and refunds are fully resolved.', 'BOKUN_txt_domain'); ?>
                         </p>
-                        <div class="bokun-booking-dashboard__dual-status-grid">
+                        <div
+                            id="<?php echo esc_attr($dual_status_panel_id); ?>"
+                            class="bokun-booking-dashboard__dual-status-grid"
+                            data-dashboard-dual-status-panel
+                            hidden
+                        >
                             <?php foreach ($booking_made_cancelled_cards as $card_html) : ?>
                                 <?php echo $card_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                             <?php endforeach; ?>
@@ -1444,6 +1504,60 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                             <p><?php esc_html_e('Thank you for understanding and patience.', 'BOKUN_txt_domain'); ?></p>
                             <p><?php esc_html_e('Best regards', 'BOKUN_txt_domain'); ?></p>
                         </section>
+                    </div>
+                </div>
+
+                <div
+                    class="bokun-booking-dashboard__history-overlay"
+                    id="<?php echo esc_attr($history_overlay_id); ?>"
+                    data-dashboard-history-overlay
+                    hidden
+                    aria-hidden="true"
+                ></div>
+                <div
+                    class="bokun-booking-dashboard__history"
+                    id="<?php echo esc_attr($history_dialog_id); ?>"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="<?php echo esc_attr($history_title_id); ?>"
+                    data-dashboard-history
+                    hidden
+                    aria-hidden="true"
+                    tabindex="-1"
+                >
+                    <div class="bokun-booking-dashboard__history-header">
+                        <h3 id="<?php echo esc_attr($history_title_id); ?>"><?php esc_html_e('Booking history', 'BOKUN_txt_domain'); ?></h3>
+                        <button type="button" class="bokun-booking-dashboard__history-close" data-dashboard-history-close aria-label="<?php esc_attr_e('Close booking history', 'BOKUN_txt_domain'); ?>">
+                            &times;
+                        </button>
+                    </div>
+                    <div class="bokun-booking-dashboard__history-body">
+                        <?php if (!empty($history_markup)) : ?>
+                            <?php echo $history_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        <?php else : ?>
+                            <p class="bokun-booking-dashboard__history-empty" role="status">
+                                <?php esc_html_e('No booking history is available yet.', 'BOKUN_txt_domain'); ?>
+                            </p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+
+                <div class="bokun-booking-dashboard__footer">
+                    <div class="bokun-booking-dashboard__footer-item" data-dashboard-user-indicator>
+                        <span class="bokun-booking-dashboard__footer-label"><?php esc_html_e('Current user', 'BOKUN_txt_domain'); ?>:</span>
+                        <span class="bokun-booking-dashboard__footer-value"><?php echo esc_html($user_display_name); ?></span>
+                    </div>
+                    <div class="bokun-booking-dashboard__footer-item bokun-booking-dashboard__footer-item--history">
+                        <button
+                            type="button"
+                            class="bokun-booking-dashboard__history-launch"
+                            data-dashboard-history-open
+                            aria-haspopup="dialog"
+                            aria-expanded="false"
+                            aria-controls="<?php echo esc_attr($history_dialog_id); ?>"
+                        >
+                            <?php esc_html_e('Booking history', 'BOKUN_txt_domain'); ?>
+                        </button>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- replace the fixed dashboard corner badges with a footer row that keeps the user indicator on the left and the booking history launcher on the right
- refresh the footer styling and responsive behavior so the badges sit within the page flow at the bottom of the dashboard

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_69083fd519708320acda3febd419f5d5