### PR TITLE
Adjust dashboard controls and spacing

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -602,8 +602,8 @@
 
 .bokun-booking-dashboard__body {
   display: grid;
-  gap: 1.5rem;
-  margin-top: 1.25rem;
+  gap: 1rem;
+  margin-top: 0.85rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   align-items: start;
 }
@@ -611,13 +611,13 @@
 .bokun-booking-dashboard__column {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .bokun-booking-dashboard__section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .bokun-booking-dashboard__status-item {
@@ -648,8 +648,8 @@
 }
 
 .bokun-booking-dashboard__dual-status {
-  margin-top: 2rem;
-  padding: 1.5rem;
+  margin-top: 1.5rem;
+  padding: 1.2rem;
   border-radius: 1rem;
   border: 1px solid #e2e8f0;
   background: #f8fafc;
@@ -697,16 +697,17 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  padding: 0.55rem 1rem;
+  gap: 0.35rem;
+  padding: 0.5rem 0.9rem;
   border-radius: 999px;
   border: 1px solid rgba(37, 99, 235, 0.4);
   background: linear-gradient(135deg, #1d4ed8, #2563eb);
   color: #ffffff;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  text-decoration: none;
 }
 
 .bokun-booking-dashboard__dual-status-toggle:hover,
@@ -828,22 +829,27 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem 1.5rem;
-  margin-top: 2rem;
-  padding-top: 1.5rem;
+  gap: 0.75rem 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
   border-top: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .bokun-booking-dashboard__footer-item {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.45rem;
   color: #0f172a;
-  background: rgba(226, 232, 240, 0.4);
-  padding: 0.65rem 1rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  background: rgba(226, 232, 240, 0.3);
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.75rem;
+  font-size: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
+}
+
+.bokun-booking-dashboard__footer-item[data-dashboard-user-indicator] {
+  background: rgba(251, 191, 36, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.45);
 }
 
 .bokun-booking-dashboard__footer-label {
@@ -860,16 +866,21 @@
 }
 
 .bokun-booking-dashboard__history-launch {
-  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: 1px solid transparent;
   background: linear-gradient(135deg, #059669, #10b981);
   color: #ffffff;
   font-weight: 600;
-  font-size: 0.85rem;
-  padding: 0.55rem 1.1rem;
+  font-size: 0.8rem;
+  padding: 0.5rem 1rem;
   border-radius: 999px;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   box-shadow: 0 16px 28px rgba(16, 185, 129, 0.35);
+  text-decoration: none;
 }
 
 .bokun-booking-dashboard__history-launch:hover,
@@ -877,6 +888,7 @@
   transform: translateY(-1px);
   box-shadow: 0 20px 36px rgba(16, 185, 129, 0.4);
   outline: none;
+  text-decoration: none;
 }
 
 .bokun-booking-dashboard__history-launch:focus-visible {
@@ -885,7 +897,7 @@
 
 .bokun-booking-dashboard__details {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.45rem;
   margin: 0;
 }
 
@@ -941,22 +953,34 @@
   font-weight: 500;
 }
 
+.bokun-booking-dashboard__section--participants {
+  padding: 0.4rem 0.55rem;
+  border-radius: 0.75rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
 .bokun-booking-dashboard__participants {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  align-items: baseline;
+  gap: 0.35rem;
   margin: 0;
-  padding: 0;
-  list-style: none;
+  font-size: 0.78rem;
+  color: #0f172a;
 }
 
-.bokun-booking-dashboard__participants li {
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.75rem;
-  background: #f1f5f9;
-  color: #1e293b;
-  font-size: 0.85rem;
+.bokun-booking-dashboard__participants-label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: #1f2937;
+}
+
+.bokun-booking-dashboard__participants-value {
   font-weight: 500;
+  color: #334155;
 }
 
 .bokun-booking-dashboard__inclusions {
@@ -967,8 +991,8 @@
 }
 
 .bokun-booking-dashboard__section-title {
-  margin: 0 0 0.5rem;
-  font-size: 0.9rem;
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
   font-weight: 700;
   color: #0f172a;
 }

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -677,6 +677,13 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 }
 
                 $phone_display = trim(sprintf('%s %s', $phone_prefix, $phone_number));
+                $phone_copy_value = $phone_display;
+                if ('' !== $phone_copy_value) {
+                    $first_space_position = strpos($phone_copy_value, ' ');
+                    if (false !== $first_space_position) {
+                        $phone_copy_value = trim(substr($phone_copy_value, $first_space_position + 1));
+                    }
+                }
 
                 $start_timestamp = get_post_time('U', true, $post_id);
 
@@ -984,13 +991,11 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                 <?php endif; ?>
 
                                 <?php if (!empty($participants)) : ?>
-                                    <div class="bokun-booking-dashboard__section">
-                                        <h4 class="bokun-booking-dashboard__section-title"><?php esc_html_e('Participants', 'BOKUN_txt_domain'); ?></h4>
-                                        <ul class="bokun-booking-dashboard__participants">
-                                            <?php foreach ($participants as $participant) : ?>
-                                                <li><?php echo esc_html($participant); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
+                                    <div class="bokun-booking-dashboard__section bokun-booking-dashboard__section--participants">
+                                        <div class="bokun-booking-dashboard__participants" role="group" aria-label="<?php esc_attr_e('Participants', 'BOKUN_txt_domain'); ?>">
+                                            <span class="bokun-booking-dashboard__participants-label"><?php esc_html_e('Participants', 'BOKUN_txt_domain'); ?>:</span>
+                                            <span class="bokun-booking-dashboard__participants-value"><?php echo esc_html(implode(' • ', $participants)); ?></span>
+                                        </div>
                                     </div>
                                 <?php endif; ?>
 
@@ -1079,7 +1084,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                                         href="#"
                                                         class="bokun-booking-dashboard__copy-button"
                                                         role="button"
-                                                        data-copy-value="<?php echo esc_attr($phone_display); ?>"
+                                                        data-copy-value="<?php echo esc_attr($phone_copy_value); ?>"
                                                         data-copy-label="<?php esc_attr_e('Copy', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-done="<?php esc_attr_e('Copied!', 'BOKUN_txt_domain'); ?>"
                                                         data-copy-error="<?php esc_attr_e('Copy failed', 'BOKUN_txt_domain'); ?>"
@@ -1437,18 +1442,19 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                                     <?php echo esc_html(number_format_i18n($dual_status_count)); ?>
                                 </span>
                             </div>
-                            <button
-                                type="button"
+                            <a
+                                href="#"
                                 class="bokun-booking-dashboard__dual-status-toggle"
                                 id="<?php echo esc_attr($dual_status_toggle_id); ?>"
                                 data-dashboard-dual-status-toggle
                                 data-show-label="<?php echo esc_attr($dual_status_show_label); ?>"
                                 data-hide-label="<?php echo esc_attr($dual_status_hide_label); ?>"
+                                role="button"
                                 aria-expanded="false"
                                 aria-controls="<?php echo esc_attr($dual_status_panel_id); ?>"
                             >
                                 <?php echo esc_html($dual_status_show_label); ?>
-                            </button>
+                            </a>
                         </div>
                         <p class="bokun-booking-dashboard__dual-status-description">
                             <?php esc_html_e('Use this list to confirm partner cancellations and refunds are fully resolved.', 'BOKUN_txt_domain'); ?>
@@ -1548,16 +1554,17 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                         <span class="bokun-booking-dashboard__footer-value"><?php echo esc_html($user_display_name); ?></span>
                     </div>
                     <div class="bokun-booking-dashboard__footer-item bokun-booking-dashboard__footer-item--history">
-                        <button
-                            type="button"
+                        <a
+                            href="#"
                             class="bokun-booking-dashboard__history-launch"
                             data-dashboard-history-open
+                            role="button"
                             aria-haspopup="dialog"
                             aria-expanded="false"
                             aria-controls="<?php echo esc_attr($history_dialog_id); ?>"
                         >
                             <?php esc_html_e('Booking history', 'BOKUN_txt_domain'); ?>
-                        </button>
+                        </a>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- convert the dual-status and booking history controls to anchor elements so they match the dashboard styling
- shrink the current user pill with a branded background while tightening vertical spacing across dashboard sections
- copy only the phone number without the country code and present participant details on a single compact line

## Testing
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_6908576cca288320a144221e161172b8