### PR TITLE
Handle empty booking imports and clean up dashboard UI

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -632,21 +632,6 @@
   line-height: 1.35;
 }
 
-.bokun-booking-dashboard__status-grid {
-  display: grid;
-  gap: 0.85rem;
-  margin-top: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.bokun-booking-dashboard__status-grid-item {
-  padding: 0.85rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid #dbeafe;
-  background: #f8fbff;
-  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.2);
-}
-
 .bokun-booking-dashboard__dual-status {
   margin-top: 1.5rem;
   padding: 1.2rem;
@@ -735,23 +720,6 @@
   display: grid;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.bokun-booking-dashboard__status-grid-label {
-  display: block;
-  margin: 0 0 0.4rem;
-  font-size: 0.78rem;
-  font-weight: 700;
-  color: #1d4ed8;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.bokun-booking-dashboard__status-grid-text {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.45;
-  color: #1f2937;
 }
 
 .bokun-booking-dashboard__history-overlay {
@@ -848,8 +816,8 @@
 }
 
 .bokun-booking-dashboard__footer-item[data-dashboard-user-indicator] {
-  background: rgba(251, 191, 36, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.45);
+  background: transparent;
+  box-shadow: none;
 }
 
 .bokun-booking-dashboard__footer-label {
@@ -870,29 +838,30 @@
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
-  border: 1px solid transparent;
-  background: linear-gradient(135deg, #059669, #10b981);
-  color: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(226, 232, 240, 0.6);
+  color: #0f172a;
   font-weight: 600;
   font-size: 0.8rem;
   padding: 0.5rem 1rem;
   border-radius: 999px;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 16px 28px rgba(16, 185, 129, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 10px 20px rgba(148, 163, 184, 0.3);
   text-decoration: none;
 }
 
 .bokun-booking-dashboard__history-launch:hover,
 .bokun-booking-dashboard__history-launch:focus {
   transform: translateY(-1px);
-  box-shadow: 0 20px 36px rgba(16, 185, 129, 0.4);
+  background: rgba(226, 232, 240, 0.85);
+  box-shadow: 0 14px 26px rgba(148, 163, 184, 0.32);
   outline: none;
   text-decoration: none;
 }
 
 .bokun-booking-dashboard__history-launch:focus-visible {
-  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.45);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
 }
 
 .bokun-booking-dashboard__details {

--- a/assets/js/bokun_admin_js.js
+++ b/assets/js/bokun_admin_js.js
@@ -340,6 +340,18 @@ jQuery(document).ready(function ($) {
                                                         isFinal: true,
                                                         context: 'fetch'
                                                 });
+                                        } else if (res.data && res.data.progress_message) {
+                                                var api1Message = decodeHTMLEntities(res.data.progress_message);
+                                                setImportProgress('summaryUpdate', {
+                                                        summary: { total: 0, processed: 0, created: 0, updated: 0, skipped: 0 },
+                                                        message: api1Message,
+                                                        isFinal: true,
+                                                        useAbsolute: true,
+                                                        context: 'fetch',
+                                                        totalItems: 0,
+                                                        current: 0,
+                                                        value: 100
+                                                });
                                         } else {
                                                 setImportProgress('api1Complete');
                                         }
@@ -402,6 +414,18 @@ jQuery(document).ready(function ($) {
                                                         label: 'Imported items from API 2',
                                                         isFinal: true,
                                                         context: 'upgrade'
+                                                });
+                                        } else if (res.data && res.data.progress_message) {
+                                                var api2Message = decodeHTMLEntities(res.data.progress_message);
+                                                setImportProgress('summaryUpdate', {
+                                                        summary: { total: 0, processed: 0, created: 0, updated: 0, skipped: 0 },
+                                                        message: api2Message,
+                                                        isFinal: true,
+                                                        useAbsolute: true,
+                                                        context: 'upgrade',
+                                                        totalItems: 0,
+                                                        current: 0,
+                                                        value: 100
                                                 });
                                         } else {
                                                 setImportProgress('api2Complete');

--- a/assets/js/bokun_front.js
+++ b/assets/js/bokun_front.js
@@ -228,6 +228,18 @@ jQuery(function ($) {
                                                                 isFinal: true,
                                                                 context: 'fetch'
                                                         });
+                                                } else if (res.data && res.data.progress_message) {
+                                                        var api1Message = decodeHTMLEntities(res.data.progress_message);
+                                                        setImportProgress('summaryUpdate', {
+                                                                summary: { total: 0, processed: 0, created: 0, updated: 0, skipped: 0 },
+                                                                message: api1Message,
+                                                                isFinal: true,
+                                                                useAbsolute: true,
+                                                                context: 'fetch',
+                                                                totalItems: 0,
+                                                                current: 0,
+                                                                value: 100
+                                                        });
                                                 } else {
                                                         setImportProgress('api1Complete');
                                                 }
@@ -289,6 +301,18 @@ jQuery(function ($) {
                                                                 label: 'Imported items from API 2',
                                                                 isFinal: true,
                                                                 context: 'upgrade'
+                                                        });
+                                                } else if (res.data && res.data.progress_message) {
+                                                        var api2Message = decodeHTMLEntities(res.data.progress_message);
+                                                        setImportProgress('summaryUpdate', {
+                                                                summary: { total: 0, processed: 0, created: 0, updated: 0, skipped: 0 },
+                                                                message: api2Message,
+                                                                isFinal: true,
+                                                                useAbsolute: true,
+                                                                context: 'upgrade',
+                                                                totalItems: 0,
+                                                                current: 0,
+                                                                value: 100
                                                         });
                                                 } else {
                                                         setImportProgress('api2Complete');

--- a/includes/bokun_settings.class.php
+++ b/includes/bokun_settings.class.php
@@ -44,7 +44,15 @@ if( !class_exists ( 'BOKUN_Settings' ) ) {
             // die;
             if (is_string($bookings)) {
                 $normalized_message = trim($bookings);
-                $is_error_message = stripos($normalized_message, 'error') === 0;
+                $is_error_message   = stripos($normalized_message, 'error') === 0;
+
+                if ($is_error_message) {
+                    $progress_message = bokun_get_import_progress_message($progress_context, 'error');
+                } else {
+                    $progress_label    = bokun_get_import_progress_label($progress_context);
+                    /* translators: %s: API label. */
+                    $progress_message  = sprintf(__('%s — no bookings found; continuing with remaining imports.', 'bokun-bookings-manager'), $progress_label);
+                }
 
                 bokun_set_import_progress_state($progress_context, array(
                     'status'    => $is_error_message ? 'error' : 'completed',
@@ -53,9 +61,16 @@ if( !class_exists ( 'BOKUN_Settings' ) ) {
                     'created'   => 0,
                     'updated'   => 0,
                     'skipped'   => 0,
-                    'message'   => $is_error_message ? bokun_get_import_progress_message($progress_context, 'error') : bokun_get_import_progress_message($progress_context, 'completed'),
+                    'message'   => $progress_message,
                 ));
-                wp_send_json_success(array('msg' => esc_html($bookings), 'status' => false));
+
+                wp_send_json_success(
+                    array(
+                        'msg'               => esc_html($bookings),
+                        'status'            => false,
+                        'progress_message'  => esc_html($progress_message),
+                    )
+                );
             } else {
                 $import_summary = bokun_save_bookings_as_posts($bookings, $progress_context);
 

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -1164,21 +1164,6 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                         </div>
                     <?php endif; ?>
 
-                    <?php if (!empty($status_guidance_entries)) : ?>
-                        <div class="bokun-booking-dashboard__status-grid" role="group" aria-label="<?php esc_attr_e('Booking status guidance', 'BOKUN_txt_domain'); ?>">
-                            <?php foreach ($status_guidance_entries as $guidance_entry) :
-                                $guidance_description = isset($guidance_entry['description']) ? trim((string) $guidance_entry['description']) : '';
-                                ?>
-                                <div class="bokun-booking-dashboard__status-grid-item">
-                                    <span class="bokun-booking-dashboard__status-grid-label"><?php echo esc_html($guidance_entry['title']); ?></span>
-                                    <?php if ($guidance_description !== '') : ?>
-                                        <p class="bokun-booking-dashboard__status-grid-text"><?php echo esc_html($guidance_description); ?></p>
-                                    <?php endif; ?>
-                                </div>
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
-
                 </article>
                 <?php
                 $card_html = ob_get_clean();


### PR DESCRIPTION
## Summary
- show a clear progress message when an API returns no bookings so the importer continues without error
- update the admin and front-end import flows to surface the note instead of the generic completion text
- remove the dashboard status guidance grid and soften the footer/user and booking history button styling

## Testing
- php -l includes/bokun_settings.class.php
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_690901ee27008320943c627898235c19