### PR TITLE
Add dynamic API credential management and partner tag inline editing

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -1215,6 +1215,77 @@
   outline: none;
 }
 
+.bokun-booking-dashboard__missing-tag-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bokun-booking-dashboard__missing-tag-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bokun-booking-dashboard__missing-tag-input {
+  padding: 0.3rem 0.65rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.4rem;
+  min-width: 10.5rem;
+  font-size: 0.8rem;
+  line-height: 1.2;
+  background-color: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bokun-booking-dashboard__missing-tag-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
+.bokun-booking-dashboard__missing-tag-save {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 0.4rem;
+  border: none;
+  background-color: #2563eb;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.bokun-booking-dashboard__missing-tag-save:hover,
+.bokun-booking-dashboard__missing-tag-save:focus {
+  background-color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.bokun-booking-dashboard__missing-tag-save:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.bokun-booking-dashboard__missing-tag-feedback {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.bokun-booking-dashboard__missing-tag-feedback.is-success {
+  color: #047857;
+}
+
+.bokun-booking-dashboard__missing-tag-feedback.is-error {
+  color: #dc2626;
+}
+
 .bokun-booking-dashboard__footer {
   margin-top: auto;
   padding-top: 0.75rem;

--- a/includes/bokun_settings.view.php
+++ b/includes/bokun_settings.view.php
@@ -1,8 +1,54 @@
 <?php
-$api_key = get_option('bokun_api_key', '');
-$secret_key = get_option('bokun_secret_key', '');
-$api_key_upgrade = get_option('bokun_api_key_upgrade', '');
-$secret_key_upgrade = get_option('bokun_secret_key_upgrade', '');
+$stored_api_credentials = get_option('bokun_api_credentials', []);
+$api_credentials = [];
+
+if (is_array($stored_api_credentials)) {
+    foreach ($stored_api_credentials as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+
+        $api_credentials[] = [
+            'api_key'    => isset($entry['api_key']) ? (string) $entry['api_key'] : '',
+            'secret_key' => isset($entry['secret_key']) ? (string) $entry['secret_key'] : '',
+        ];
+    }
+}
+
+if (empty($api_credentials)) {
+    $legacy_primary = [
+        'api_key'    => get_option('bokun_api_key', ''),
+        'secret_key' => get_option('bokun_secret_key', ''),
+    ];
+
+    $legacy_secondary = [
+        'api_key'    => get_option('bokun_api_key_upgrade', ''),
+        'secret_key' => get_option('bokun_secret_key_upgrade', ''),
+    ];
+
+    foreach ([$legacy_primary, $legacy_secondary] as $legacy_entry) {
+        $legacy_api_key    = isset($legacy_entry['api_key']) ? trim((string) $legacy_entry['api_key']) : '';
+        $legacy_secret_key = isset($legacy_entry['secret_key']) ? trim((string) $legacy_entry['secret_key']) : '';
+
+        if ('' === $legacy_api_key && '' === $legacy_secret_key) {
+            continue;
+        }
+
+        $api_credentials[] = [
+            'api_key'    => $legacy_api_key,
+            'secret_key' => $legacy_secret_key,
+        ];
+    }
+}
+
+if (empty($api_credentials)) {
+    $api_credentials[] = [
+        'api_key'    => '',
+        'secret_key' => '',
+    ];
+}
+
+$next_api_index = count($api_credentials);
 $dashboard_page_id = (int) get_option('bokun_dashboard_page_id', 0);
 $dashboard_page_dropdown = wp_dropdown_pages(
     array(
@@ -21,57 +67,77 @@ $dashboard_page_dropdown = wp_dropdown_pages(
 
         <div class="row">
             
-            <div class="col-4 text-center ">
+            <div class="col-8">
                 <div class="card">
-                    <h2>Manage Bokun API Keys 1</h2>
+                    <h2><?php esc_html_e('Manage Bokun API Keys', 'BOKUN_txt_domain'); ?></h2>
+                    <p class="description">
+                        <?php esc_html_e('Store one or more Bokun API credentials. Each set will be used during the import process.', 'BOKUN_txt_domain'); ?>
+                    </p>
                     <div class="notice notice-info is-dismissible msg_success_apis" style="display:none;">
                         <p>
-                            <strong>Success:</strong>
+                            <strong><?php esc_html_e('Success:', 'BOKUN_txt_domain'); ?></strong>
                         </p>
                     </div>
                     <div class="notice notice-error is-dismissible msg_error_apis" style="display:none;">
                         <p>
-                            <strong>Error:</strong>
+                            <strong><?php esc_html_e('Error:', 'BOKUN_txt_domain'); ?></strong>
                         </p>
                     </div>
-                    <form method="post" action="javascript:;" id="bokun_api_auth_form" name="bokun_api_auth_form" enctype='multipart/form-data'>
-                        <div class="bokun_cmrc-table">
-                            <div class="bokun_settings-fb-config">                                
-                                <label for="api_key">API Key:</label>
-                                <input type="text" name="api_key" value="<?= $api_key ?>" placeholder="Enter your API key" required><br>
-                                <label for="secret_key">Secret Key:</label>
-                                <input type="text" name="secret_key" value="<?= $secret_key ?>" placeholder="Enter your Secret key" required><br>
-                                <input type="submit" name="submit" class="button button-primary bokun_api_auth_save" value="Save Keys">
+                    <form method="post" action="javascript:;" id="bokun_api_credentials_form" name="bokun_api_credentials_form" enctype='multipart/form-data'>
+                        <div class="bokun_cmrc-table" data-api-credentials-wrapper>
+                            <div class="bokun_api_credentials" data-api-credentials-list data-next-index="<?php echo esc_attr($next_api_index); ?>">
+                                <?php foreach ($api_credentials as $index => $credential) :
+                                    $field_index = (int) $index;
+                                    $api_key_value = isset($credential['api_key']) ? $credential['api_key'] : '';
+                                    $secret_key_value = isset($credential['secret_key']) ? $credential['secret_key'] : '';
+                                    $item_label = sprintf(__('API #%d', 'BOKUN_txt_domain'), $field_index + 1);
+                                ?>
+                                    <div class="bokun_api_credentials__item" data-api-credentials-item data-index="<?php echo esc_attr($field_index); ?>">
+                                        <div class="bokun_api_credentials__item-header">
+                                            <span class="bokun_api_credentials__item-title"><?php echo esc_html($item_label); ?></span>
+                                            <button type="button" class="button-link-delete bokun_api_credentials__item-remove" data-api-credentials-remove aria-label="<?php esc_attr_e('Remove API credential', 'BOKUN_txt_domain'); ?>">
+                                                <?php esc_html_e('Remove', 'BOKUN_txt_domain'); ?>
+                                            </button>
+                                        </div>
+                                        <div class="bokun_api_credentials__fields">
+                                            <label>
+                                                <?php esc_html_e('API Key', 'BOKUN_txt_domain'); ?>
+                                                <input type="text" name="api_credentials[<?php echo esc_attr($field_index); ?>][api_key]" value="<?php echo esc_attr($api_key_value); ?>" autocomplete="off">
+                                            </label>
+                                            <label>
+                                                <?php esc_html_e('Secret Key', 'BOKUN_txt_domain'); ?>
+                                                <input type="text" name="api_credentials[<?php echo esc_attr($field_index); ?>][secret_key]" value="<?php echo esc_attr($secret_key_value); ?>" autocomplete="off">
+                                            </label>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                            <div class="bokun_api_credentials__actions">
+                                <button type="button" class="button" data-api-credentials-add><?php esc_html_e('Add another API', 'BOKUN_txt_domain'); ?></button>
+                                <input type="submit" name="submit" class="button button-primary bokun_api_credentials_save" value="<?php esc_attr_e('Save API keys', 'BOKUN_txt_domain'); ?>">
                             </div>
                         </div>
                     </form>
-                </div>
-            </div>
-
-            <div class="col-4 text-center ">
-                <div class="card">
-                    <h2>Manage Bokun API Keys 2</h2>
-                    <div class="notice notice-info is-dismissible msg_success_apis_upgrade" style="display:none;">
-                        <p>
-                            <strong>Success:</strong>
-                        </p>
-                    </div>
-                    <div class="notice notice-error is-dismissible msg_error_apis_upgrade" style="display:none;">
-                        <p>
-                            <strong>Error:</strong>
-                        </p>
-                    </div>
-                    <form method="post" action="javascript:;" id="bokun_api_auth_form_upgrade" name="bokun_api_auth_form_upgrade" enctype='multipart/form-data'>
-                        <div class="bokun_cmrc-table">
-                            <div class="bokun_settings-fb-config">                                
-                                <label for="api_key_upgrade">API Key:</label>
-                                <input type="text" name="api_key_upgrade" value="<?= $api_key_upgrade ?>" placeholder="Enter your API key" required><br>
-                                <label for="secret_key">Secret Key:</label>
-                                <input type="text" name="secret_key_upgrade" value="<?= $secret_key_upgrade ?>" placeholder="Enter your Secret key" required><br>
-                                <input type="submit" name="submit" class="button button-primary bokun_api_auth_save_upgrade" value="Save Keys">
+                    <template id="bokun-api-credential-template">
+                        <div class="bokun_api_credentials__item" data-api-credentials-item data-index="__index__">
+                            <div class="bokun_api_credentials__item-header">
+                                <span class="bokun_api_credentials__item-title"><?php esc_html_e('API', 'BOKUN_txt_domain'); ?> __number__</span>
+                                <button type="button" class="button-link-delete bokun_api_credentials__item-remove" data-api-credentials-remove aria-label="<?php esc_attr_e('Remove API credential', 'BOKUN_txt_domain'); ?>">
+                                    <?php esc_html_e('Remove', 'BOKUN_txt_domain'); ?>
+                                </button>
+                            </div>
+                            <div class="bokun_api_credentials__fields">
+                                <label>
+                                    <?php esc_html_e('API Key', 'BOKUN_txt_domain'); ?>
+                                    <input type="text" name="api_credentials[__index__][api_key]" value="" autocomplete="off">
+                                </label>
+                                <label>
+                                    <?php esc_html_e('Secret Key', 'BOKUN_txt_domain'); ?>
+                                    <input type="text" name="api_credentials[__index__][secret_key]" value="" autocomplete="off">
+                                </label>
                             </div>
                         </div>
-                    </form>
+                    </template>
                 </div>
             </div>
 
@@ -85,17 +151,6 @@ $dashboard_page_dropdown = wp_dropdown_pages(
                         </p>
                     </div>
                     <div class="notice notice-error is-dismissible msg_error msg_sec" style="display:none;">
-                        <p>
-                            <strong>Error:</strong>
-                        </p>
-                    </div>
-                    <p class="for_api_2 msg_success_upgrade msg_sec" style="display:none;">For API 2</p>
-                    <div class="notice notice-info is-dismissible msg_success_upgrade msg_sec"  style="display:none;">
-                        <p>
-                            <strong>Success:</strong>
-                        </p>
-                    </div>
-                    <div class="notice notice-error is-dismissible msg_error_upgrade msg_sec" style="display:none;">
                         <p>
                             <strong>Error:</strong>
                         </p>

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -817,6 +817,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                             if ($term_partner_id === '') {
                                 $edit_link = get_edit_term_link($term, 'product_tags');
                                 $product_tags_without_partner[$term->term_id] = [
+                                    'term_id'  => $term->term_id,
                                     'name'      => $term->name,
                                     'edit_link' => (!is_wp_error($edit_link) && !empty($edit_link)) ? $edit_link : '',
                                 ];
@@ -1556,14 +1557,41 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                     <div class="bokun-booking-dashboard__missing-tags">
                         <h3><?php esc_html_e('Product tags without link to partner website:', 'BOKUN_txt_domain'); ?></h3>
                         <ul class="bokun-booking-dashboard__missing-tags-list">
-                            <?php foreach ($product_tags_without_partner as $term_data) : ?>
-                                <li class="bokun-booking-dashboard__missing-tags-item">
+                            <?php foreach ($product_tags_without_partner as $term_data) :
+                                $term_id = isset($term_data['term_id']) ? (int) $term_data['term_id'] : 0;
+                                $input_id = $term_id > 0 ? sprintf('partner-page-id-%d', $term_id) : uniqid('partner-page-id-');
+                            ?>
+                                <li class="bokun-booking-dashboard__missing-tags-item" data-partner-tag-item>
                                     <span class="bokun-booking-dashboard__missing-tag-name"><?php echo esc_html($term_data['name']); ?></span>
-                                    <?php if (!empty($term_data['edit_link'])) : ?>
-                                        <a href="<?php echo esc_url($term_data['edit_link']); ?>" target="_blank" rel="noopener noreferrer" class="bokun-booking-dashboard__missing-tag-link">
-                                            <?php esc_html_e('Edit tag', 'BOKUN_txt_domain'); ?>
-                                        </a>
-                                    <?php endif; ?>
+                                    <div class="bokun-booking-dashboard__missing-tag-actions">
+                                        <?php if (!empty($term_data['edit_link'])) : ?>
+                                            <a href="<?php echo esc_url($term_data['edit_link']); ?>" target="_blank" rel="noopener noreferrer" class="bokun-booking-dashboard__missing-tag-link">
+                                                <?php esc_html_e('Edit tag', 'BOKUN_txt_domain'); ?>
+                                            </a>
+                                        <?php endif; ?>
+                                        <form class="bokun-booking-dashboard__missing-tag-form" data-partner-tag-form data-term-id="<?php echo esc_attr($term_id); ?>">
+                                            <label class="screen-reader-text" for="<?php echo esc_attr($input_id); ?>"><?php esc_html_e('Partner Page ID', 'BOKUN_txt_domain'); ?></label>
+                                            <input
+                                                type="text"
+                                                id="<?php echo esc_attr($input_id); ?>"
+                                                name="partner_page_id"
+                                                class="bokun-booking-dashboard__missing-tag-input"
+                                                placeholder="<?php esc_attr_e('Enter Partner Page ID', 'BOKUN_txt_domain'); ?>"
+                                                data-partner-page-input
+                                            >
+                                            <button type="submit" class="bokun-booking-dashboard__missing-tag-save" data-partner-page-submit>
+                                                <?php esc_html_e('Save', 'BOKUN_txt_domain'); ?>
+                                            </button>
+                                            <span
+                                                class="bokun-booking-dashboard__missing-tag-feedback"
+                                                data-partner-page-feedback
+                                                role="status"
+                                                aria-live="polite"
+                                                aria-hidden="true"
+                                                hidden
+                                            ></span>
+                                        </form>
+                                    </div>
                                 </li>
                             <?php endforeach; ?>
                         </ul>


### PR DESCRIPTION
## Summary
- replace the static API key inputs with a repeatable list that supports any number of credential pairs and wire it through the existing AJAX save endpoint
- update the admin/front-end import logic to iterate through all configured API contexts, track progress dynamically, and expose inline Partner Page ID forms for missing product tags
- add the server-side plumbing for the new credential storage and secure Partner Page ID updates

## Testing
- php -l includes/bokun-bookings-manager.php
- php -l includes/bokun_shortcode.class.php

------
https://chatgpt.com/codex/tasks/task_e_6909508017948320b57d5f6b60a957a5