### PR TITLE
Show import notification after all APIs finish

### DIFF
--- a/assets/js/bokun_admin_js.js
+++ b/assets/js/bokun_admin_js.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function ($) {
         var progressPollInterval = 1000;
         var apiContexts = Array.isArray(bokun_api_auth_vars && bokun_api_auth_vars.apiContexts) ? bokun_api_auth_vars.apiContexts : [];
         var apiContextMap = {};
+        var importNotificationMessages = [];
 
         apiContexts = apiContexts.filter(function (context) {
                 return context && typeof context === 'object';
@@ -517,6 +518,7 @@ jQuery(document).ready(function ($) {
                 if (index >= apiContexts.length) {
                         setImportProgress('allComplete', { totalContexts: apiContexts.length });
                         $button.prop('disabled', false).val('Fetch');
+                        showFinalImportNotification();
                         return;
                 }
 
@@ -574,7 +576,7 @@ jQuery(document).ready(function ($) {
                                 }
 
                                 if (res.data && res.data.msg) {
-                                        alert(decodeHTMLEntities(res.data.msg));
+                                        recordImportNotification(contextLabel, res.data.msg);
                                 }
 
                                 runAdminImportSequence(index + 1);
@@ -627,6 +629,7 @@ jQuery(document).ready(function ($) {
                 stopAllImportProgressPolling();
                 resetImportProgressState();
                 setImportProgress('reset');
+                resetImportNotifications();
 
                 runAdminImportSequence(0);
         });
@@ -724,6 +727,33 @@ jQuery(document).ready(function ($) {
                 var tempElement = document.createElement('textarea');
                 tempElement.innerHTML = text;
                 return tempElement.value;
+        }
+
+        function resetImportNotifications() {
+                importNotificationMessages = [];
+        }
+
+        function recordImportNotification(contextLabel, message) {
+                if (!message) {
+                        return;
+                }
+
+                var normalized = decodeHTMLEntities(message);
+                var labeledMessage = contextLabel ? (contextLabel + ': ' + normalized) : normalized;
+
+                importNotificationMessages.push(labeledMessage);
+        }
+
+        function showFinalImportNotification() {
+                var message;
+
+                if (importNotificationMessages.length) {
+                        message = importNotificationMessages.join('\n');
+                } else {
+                        message = 'Import complete.';
+                }
+
+                alert(message);
         }
 
         function setImportProgress(step, options) {

--- a/assets/js/bokun_front.js
+++ b/assets/js/bokun_front.js
@@ -5,6 +5,7 @@ jQuery(function ($) {
         var progressPollInterval = 1000;
         var apiContexts = Array.isArray(bokun_api_auth_vars && bokun_api_auth_vars.apiContexts) ? bokun_api_auth_vars.apiContexts : [];
         var apiContextMap = {};
+        var importNotificationMessages = [];
 
         apiContexts = apiContexts.filter(function (context) {
                 return context && (typeof context === 'object');
@@ -283,6 +284,7 @@ jQuery(function ($) {
                 if (index >= apiContexts.length) {
                         setImportProgress('allComplete', { totalContexts: apiContexts.length });
                         $button.text('Fetch').prop('disabled', false);
+                        showFinalImportNotification();
                         return;
                 }
 
@@ -340,7 +342,7 @@ jQuery(function ($) {
                                 }
 
                                 if (res.data && res.data.msg) {
-                                        alert(decodeHTMLEntities(res.data.msg));
+                                        recordImportNotification(contextLabel, res.data.msg);
                                 }
 
                                 runContextImportSequence(index + 1);
@@ -394,6 +396,7 @@ jQuery(function ($) {
                 stopAllImportProgressPolling();
                 resetImportProgressState();
                 setImportProgress('reset');
+                resetImportNotifications();
 
                 runContextImportSequence(0);
         });
@@ -402,6 +405,33 @@ jQuery(function ($) {
                 var tempElement = document.createElement('textarea');
                 tempElement.innerHTML = text;
                 return tempElement.value;
+        }
+
+        function resetImportNotifications() {
+                importNotificationMessages = [];
+        }
+
+        function recordImportNotification(contextLabel, message) {
+                if (!message) {
+                        return;
+                }
+
+                var normalized = decodeHTMLEntities(message);
+                var labeledMessage = contextLabel ? (contextLabel + ': ' + normalized) : normalized;
+
+                importNotificationMessages.push(labeledMessage);
+        }
+
+        function showFinalImportNotification() {
+                var message;
+
+                if (importNotificationMessages.length) {
+                        message = importNotificationMessages.join('\n');
+                } else {
+                        message = 'Import complete.';
+                }
+
+                alert(message);
         }
 
         function setImportProgress(step, options) {


### PR DESCRIPTION
## Summary
- collect import messages per API and display a single notification after all contexts finish
- remove per-context alerts during admin and frontend fetch sequences so imports continue automatically
- reset stored notifications each time a new fetch run starts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a3d2616f88320bbce0657509298d8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates import notifications so imports run uninterrupted and users see a single summary at the end.
> 
> - Add `importNotificationMessages` and helpers: `resetImportNotifications`, `recordImportNotification`, `showFinalImportNotification`
> - Replace per-context `alert(...)` with `recordImportNotification(...)` during admin/frontend fetch sequences
> - Call `showFinalImportNotification()` when all contexts finish; call `resetImportNotifications()` at fetch start
> - Updated in `assets/js/bokun_admin_js.js` and `assets/js/bokun_front.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85019c1b19ab70d9db8d61e9925eaa78e91984af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->