### PR TITLE
Improve booking history date sorting

### DIFF
--- a/includes/bokun_booking_history.view.php
+++ b/includes/bokun_booking_history.view.php
@@ -43,6 +43,7 @@ if (!empty($logs)) {
     foreach ($logs as $log) {
         $timestamp      = strtotime($log['created_at']);
         $formatted_date = $timestamp ? date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $timestamp) : $log['created_at'];
+        $sortable_date  = $timestamp ? $timestamp : 0;
         $action_label   = ucwords(str_replace('-', ' ', $log['action_type']));
         $status_label   = $log['is_checked'] ? __('Checked', 'BOKUN_txt_domain') : __('Unchecked', 'BOKUN_txt_domain');
         $actor_label    = $log['user_name'];
@@ -111,6 +112,7 @@ if (!empty($logs)) {
             'actor_value'  => $actor_value,
             'source_label' => $source_label,
             'source_value' => $source_value,
+            'sort_date'    => $sortable_date,
         ];
     }
 
@@ -363,7 +365,7 @@ if (!empty($logs)) {
                         data-status="<?php echo esc_attr($log['status_value']); ?>"
                         data-actor="<?php echo esc_attr($log['actor_value']); ?>"
                         data-source="<?php echo esc_attr($log['source_value']); ?>">
-                        <td><?php echo esc_html($log['date']); ?></td>
+                        <td data-order="<?php echo esc_attr($log['sort_date']); ?>"><?php echo esc_html($log['date']); ?></td>
                         <td>
                             <?php if (!empty($log['booking_link'])) : ?>
                                 <a href="<?php echo esc_url($log['booking_link']); ?>"><?php echo esc_html($log['booking_id']); ?></a>

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -189,6 +189,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
             foreach ($logs as $log) {
                 $timestamp = strtotime($log['created_at']);
                 $formatted_date = $timestamp ? date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $timestamp) : $log['created_at'];
+                $sortable_date  = $timestamp ? $timestamp : 0;
                 $action_label = ucwords(str_replace('-', ' ', $log['action_type']));
                 $status_label = !empty($log['is_checked']) ? __('Checked', 'BOKUN_txt_domain') : __('Unchecked', 'BOKUN_txt_domain');
                 $actor_label  = $log['user_name'];
@@ -261,6 +262,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                     'actor_value'    => $actor_value,
                     'source_label'   => $source_label,
                     'source_value'   => $source_value,
+                    'sort_date'      => $sortable_date,
                 ];
             }
 
@@ -492,7 +494,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                     <tbody>
                         <?php foreach ($processed_logs as $log) : ?>
                             <tr data-action="<?php echo esc_attr($log['action_value']); ?>" data-status="<?php echo esc_attr($log['status_value']); ?>" data-actor="<?php echo esc_attr($log['actor_value']); ?>" data-source="<?php echo esc_attr($log['source_value']); ?>">
-                                <td data-title="<?php esc_attr_e('Date', 'BOKUN_txt_domain'); ?>"><?php echo esc_html($log['date']); ?></td>
+                                <td data-title="<?php esc_attr_e('Date', 'BOKUN_txt_domain'); ?>" data-order="<?php echo esc_attr($log['sort_date']); ?>"><?php echo esc_html($log['date']); ?></td>
                                 <td data-title="<?php esc_attr_e('Booking ID', 'BOKUN_txt_domain'); ?>"><?php echo wp_kses_post($log['booking_display']); ?></td>
                                 <td data-title="<?php esc_attr_e('Action', 'BOKUN_txt_domain'); ?>"><?php echo esc_html($log['action_label']); ?></td>
                                 <td data-title="<?php esc_attr_e('Status', 'BOKUN_txt_domain'); ?>"><?php echo esc_html($log['status_label']); ?></td>


### PR DESCRIPTION
## Summary
- add sortable timestamps to booking history table rows for DataTables sorting accuracy
- use numeric ordering on both shortcode and admin booking history views to align displayed dates with sort order

## Testing
- php -l includes/bokun_shortcode.class.php
- php -l includes/bokun_booking_history.view.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a4138939c83208b89917fcb5aa876)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves date sorting accuracy in booking history tables by supplying numeric timestamps for sorting while keeping localized display.
> 
> - Compute `sort_date` (Unix timestamp) for each log and include it in `processed_logs`
> - Use `data-order="sort_date"` on the Date column in both admin view (`bokun_booking_history.view.php`) and shortcode table (`bokun_shortcode.class.php`) so DataTables sorts numerically
> - Minor: add missing newline at end of file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2433fe1e85404901164a34d5de5c450a5aa2be2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->