### PR TITLE
Make toggle texts non-clickable, underline title links, and tighten toggle gap

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -473,7 +473,7 @@
 
 .bokun-booking-dashboard__title a {
   color: inherit;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .bokun-booking-dashboard__title a:hover,
@@ -1025,10 +1025,9 @@
 .bokun-booking-dashboard__toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.1rem;
   font-size: 0.85rem;
   color: #0f172a;
-  cursor: pointer;
 }
 
 .bokun-booking-dashboard__toggle input[type="checkbox"] {
@@ -1316,4 +1315,3 @@
 .bokun-booking-dashboard__card.alarm_status-ok {
   border-color: #0f172a;
 }
-

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -972,23 +972,23 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
 
                     <div class="bokun-booking-dashboard__toggles" role="group" aria-label="<?php esc_attr_e('Booking status toggles', 'BOKUN_txt_domain'); ?>">
                         <span class="bokun-booking-dashboard__toggle-label"><?php esc_html_e('Result:', 'BOKUN_txt_domain'); ?></span>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="full" <?php echo checked($checkbox_states['full'], true, false); ?> />
+                        <div class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="full" aria-label="<?php esc_attr_e('Full', 'BOKUN_txt_domain'); ?>" <?php echo checked($checkbox_states['full'], true, false); ?> />
                             <span><?php esc_html_e('Full', 'BOKUN_txt_domain'); ?></span>
-                        </label>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="partial" <?php echo checked($checkbox_states['partial'], true, false); ?> />
+                        </div>
+                        <div class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="partial" aria-label="<?php esc_attr_e('Partial', 'BOKUN_txt_domain'); ?>" <?php echo checked($checkbox_states['partial'], true, false); ?> />
                             <span><?php esc_html_e('Partial', 'BOKUN_txt_domain'); ?></span>
-                        </label>
-                        <label class="bokun-booking-dashboard__toggle">
-                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="not-available" <?php echo checked($checkbox_states['not-available'], true, false); ?> />
+                        </div>
+                        <div class="bokun-booking-dashboard__toggle">
+                            <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="not-available" aria-label="<?php esc_attr_e('Not available', 'BOKUN_txt_domain'); ?>" <?php echo checked($checkbox_states['not-available'], true, false); ?> />
                             <span><?php esc_html_e('Not available', 'BOKUN_txt_domain'); ?></span>
-                        </label>
+                        </div>
                         <?php if ($show_refund_toggle) : ?>
-                            <label class="bokun-booking-dashboard__toggle">
-                                <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="refund-partner" <?php echo checked($checkbox_states['refund-partner'], true, false); ?> />
+                            <div class="bokun-booking-dashboard__toggle">
+                                <input type="checkbox" class="booking-checkbox" data-booking-id="<?php echo esc_attr($booking_code); ?>" data-type="refund-partner" aria-label="<?php esc_attr_e('Refund requested', 'BOKUN_txt_domain'); ?>" <?php echo checked($checkbox_states['refund-partner'], true, false); ?> />
                                 <span><?php esc_html_e('Refund requested', 'BOKUN_txt_domain'); ?></span>
-                            </label>
+                            </div>
                         <?php endif; ?>
                     </div>
 


### PR DESCRIPTION
### Motivation
- Ensure only the checkbox itself toggles booking result states instead of the whole label text being clickable to avoid accidental toggles.
- Visually underline dashboard title links to match design intent for link affordance. 
- Reduce spacing between checkbox and label text to better align compact UI.
- Improve accessibility by providing `aria-label` on checkbox inputs.

### Description
- Replaced `label` wrappers with non-clickable `div` wrappers around checkboxes in `includes/bokun_shortcode.class.php` so clicking the text no longer toggles the checkbox. 
- Added `aria-label` attributes to each checkbox input (e.g. `data-type="full"`, `partial`, `not-available`, and `refund-partner`).
- Updated `assets/css/bokun_front.css` to set `.bokun-booking-dashboard__title a` `text-decoration` to `underline` and changed `.bokun-booking-dashboard__toggle` `gap` from `0.4rem` to `0.1rem`.
- Modified files: `includes/bokun_shortcode.class.php` and `assets/css/bokun_front.css`.

### Testing
- No automated tests were run for these changes. 
- Changes were committed to the working branch successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950572944908320809c754a4a39c85d)