### PR TITLE
Use dashboard accent variables for Reserve link and tighten spacing

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -120,6 +120,8 @@
 
 .bokun-booking-dashboard {
   --bokun-booking-dashboard-columns: 3;
+  --bokun-booking-dashboard-accent: #7b1e3a;
+  --bokun-booking-dashboard-accent-dark: #5f152c;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -523,7 +525,7 @@
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);
+  background: var(--bokun-booking-dashboard-accent);
   color: #ffffff;
   padding: 0.4rem 1rem;
   font-size: 0.75rem;
@@ -531,20 +533,20 @@
   letter-spacing: 0.02em;
   text-decoration: none;
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 10px 20px rgba(123, 30, 58, 0.25);
 }
 
 .bokun-booking-dashboard__reserve-link:hover,
 .bokun-booking-dashboard__reserve-link:focus {
-  background: linear-gradient(135deg, #1d4ed8 0%, #4338ca 100%);
+  background: var(--bokun-booking-dashboard-accent-dark);
   color: #ffffff;
   transform: translateY(-1px);
   outline: none;
-  box-shadow: 0 12px 28px rgba(29, 78, 216, 0.35);
+  box-shadow: 0 12px 28px rgba(95, 21, 44, 0.35);
 }
 
 .bokun-booking-dashboard__vendor {
-  margin: 0.25rem 0 0;
+  margin: -0.1rem 0 0;
   font-size: 1rem;
   font-weight: 700;
 }
@@ -554,7 +556,7 @@
 }
 
 .bokun-booking-dashboard__vendor--accent {
-  color: #7b1e3a;
+  color: var(--bokun-booking-dashboard-accent);
 }
 
 


### PR DESCRIPTION
### Motivation
- Make the `Reserve link` button follow the same accent color as the vendor label so its color can be changed dynamically.  
- Reduce vertical space between the reserve link button and the vendor line to visually group them more closely.  
- Centralize accent colors for the booking dashboard in CSS variables to simplify theming.  

### Description
- Added CSS variables `--bokun-booking-dashboard-accent` and `--bokun-booking-dashboard-accent-dark` to the `:root` of the dashboard block in `assets/css/bokun_front.css`.  
- Updated `.bokun-booking-dashboard__reserve-link` to use `var(--bokun-booking-dashboard-accent)` for its background and `var(--bokun-booking-dashboard-accent-dark)` for hover state, and adjusted its box-shadow colors accordingly.  
- Changed `.bokun-booking-dashboard__vendor` top margin to a small negative value to reduce spacing between the link and vendor text.  
- Made `.bokun-booking-dashboard__vendor--accent` use the new `--bokun-booking-dashboard-accent` variable so both elements pick up the same accent color.  

### Testing
- No automated tests were executed as part of this change.  
- CSS file `assets/css/bokun_front.css` was updated and committed successfully.  
- Manual visual verification was intended (not run in this environment).  
- No build or lint jobs were triggered by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950586739d4832088a2c0a57ce4fb39)