### PR TITLE
Match reserve link color to vendor accent

### DIFF
--- a/assets/css/bokun_front.css
+++ b/assets/css/bokun_front.css
@@ -522,10 +522,14 @@
 }
 
 .bokun-booking-dashboard__reserve-link {
+  --bokun-booking-dashboard-reserve-link-bg: var(--bokun-booking-dashboard-accent);
+  --bokun-booking-dashboard-reserve-link-bg-hover: var(--bokun-booking-dashboard-accent-dark);
+  --bokun-booking-dashboard-reserve-link-shadow: 0 10px 20px rgba(123, 30, 58, 0.25);
+  --bokun-booking-dashboard-reserve-link-shadow-hover: 0 12px 28px rgba(95, 21, 44, 0.35);
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  background: var(--bokun-booking-dashboard-accent);
+  background: var(--bokun-booking-dashboard-reserve-link-bg);
   color: #ffffff;
   padding: 0.4rem 1rem;
   font-size: 0.75rem;
@@ -533,16 +537,30 @@
   letter-spacing: 0.02em;
   text-decoration: none;
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 10px 20px rgba(123, 30, 58, 0.25);
+  box-shadow: var(--bokun-booking-dashboard-reserve-link-shadow);
+}
+
+.bokun-booking-dashboard__reserve-link--accent {
+  --bokun-booking-dashboard-reserve-link-bg: var(--bokun-booking-dashboard-accent);
+  --bokun-booking-dashboard-reserve-link-bg-hover: var(--bokun-booking-dashboard-accent-dark);
+  --bokun-booking-dashboard-reserve-link-shadow: 0 10px 20px rgba(123, 30, 58, 0.25);
+  --bokun-booking-dashboard-reserve-link-shadow-hover: 0 12px 28px rgba(95, 21, 44, 0.35);
+}
+
+.bokun-booking-dashboard__reserve-link--highlight {
+  --bokun-booking-dashboard-reserve-link-bg: #2563eb;
+  --bokun-booking-dashboard-reserve-link-bg-hover: #1d4ed8;
+  --bokun-booking-dashboard-reserve-link-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+  --bokun-booking-dashboard-reserve-link-shadow-hover: 0 12px 28px rgba(30, 64, 175, 0.35);
 }
 
 .bokun-booking-dashboard__reserve-link:hover,
 .bokun-booking-dashboard__reserve-link:focus {
-  background: var(--bokun-booking-dashboard-accent-dark);
+  background: var(--bokun-booking-dashboard-reserve-link-bg-hover);
   color: #ffffff;
   transform: translateY(-1px);
   outline: none;
-  box-shadow: 0 12px 28px rgba(95, 21, 44, 0.35);
+  box-shadow: var(--bokun-booking-dashboard-reserve-link-shadow-hover);
 }
 
 .bokun-booking-dashboard__vendor {

--- a/includes/bokun_shortcode.class.php
+++ b/includes/bokun_shortcode.class.php
@@ -905,6 +905,12 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                 }
 
                 $show_refund_toggle = $requires_refund_followup;
+                $vendor_class = !empty($vendor_title) && stripos($vendor_title, 'Florence Adventures') !== false
+                    ? 'bokun-booking-dashboard__vendor--highlight'
+                    : 'bokun-booking-dashboard__vendor--accent';
+                $reserve_link_class = $vendor_class === 'bokun-booking-dashboard__vendor--highlight'
+                    ? 'bokun-booking-dashboard__reserve-link bokun-booking-dashboard__reserve-link--highlight'
+                    : 'bokun-booking-dashboard__reserve-link bokun-booking-dashboard__reserve-link--accent';
 
                 ob_start();
                 ?>
@@ -945,7 +951,7 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                             </div>
                             <?php if (!empty($partner_page_url)) : ?>
                                 <a
-                                    class="bokun-booking-dashboard__reserve-link"
+                                    class="<?php echo esc_attr($reserve_link_class); ?>"
                                     href="<?php echo esc_url($partner_page_url); ?>"
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -955,11 +961,6 @@ if( !class_exists ( 'BOKUN_Shortcode' ) ) {
                             <?php endif; ?>
                         </div>
                         <?php if (!empty($vendor_title)) : ?>
-                            <?php
-                            $vendor_class = (stripos($vendor_title, 'Florence Adventures') !== false)
-                                ? 'bokun-booking-dashboard__vendor--highlight'
-                                : 'bokun-booking-dashboard__vendor--accent';
-                            ?>
                             <p class="bokun-booking-dashboard__vendor <?php echo esc_attr($vendor_class); ?>">
                                 <?php echo esc_html($vendor_title); ?>
                             </p>


### PR DESCRIPTION
### Motivation
- Fix visual mismatch where the "Reserve link" button color did not reflect the vendor label color.
- Ensure the reserve button color is dynamic and follows the same vendor accent/highlight logic used for the vendor name.
- Keep hover and shadow states consistent with the chosen accent for improved appearance.

### Description
- Compute `vendor_class` earlier and derive a `reserve_link_class` in `includes/bokun_shortcode.class.php` and use `<?php echo esc_attr($reserve_link_class); ?>` for the reserve anchor.
- Replace the fixed `.bokun-booking-dashboard__reserve-link` background with CSS variables and use `--bokun-booking-dashboard-reserve-link-*` variables to control background and shadow in `assets/css/bokun_front.css`.
- Add modifier classes `.bokun-booking-dashboard__reserve-link--accent` and `--highlight` to map the reserve link to the corresponding vendor accent or highlight palette.
- Update hover/focus rules to use the new variables so the reserve link hover/shadow match the selected accent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950595a3c308320936c2fdb1ef46775)